### PR TITLE
EASY-2790: dataset.xml bevat <not:implemented/>

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/Filter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/Filter.scala
@@ -33,6 +33,7 @@ trait Filter extends DebugEnhancedLogging {
     val triedMaybeVaultResponse: Try[Option[String]] = maybeDoi
       .map(targetIndex.getByDoi)
       .getOrElse(Success(None)) // no DOI => no bag found by DOI
+    if (maybeDoi.isDefined && triedMaybeVaultResponse.get.isEmpty) logger.info(s"doi ${maybeDoi.get} not found in bag-index")
     val violations = Seq(
       "1: DANS DOI" -> (if (maybeDoi.isEmpty) Seq("not found")
                         else Seq[String]()),


### PR DESCRIPTION
Fixes EASY-2790

#### As first step to find out what is going wrong:
* added logging when the `doi` is not found in `bag-index` (that means that it is not in the `vault` and the bag can be handled futher)


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
