### PR TITLE
DD-208: Versioning with only original files in first bag 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ For every dataset in the output there is a bag-dir created in the `<output-dir>`
 Furthermore, a `<log-file>` is generated in csv format with the following headers:
 
     easy-dataset-id  input easy-dataset-id
-    UUID             UUID created for the resulting AIP
+    UUID             UUID created for the resulting package of the specified output format
     doi              doi as it appears in the EMD
     depositor        EASY-User-Account of the depositor of the dataset
     transformation   transformation used

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,8 @@ ARGUMENTS
      -v, --version                Show version of this program
     
     trailing arguments:
-     transformation (required)   The type of transformation used: simple, thematische-collectie.
+     transformation (required)   The type of transformation used: simple, thematische-collectie,
+                                 original-versioned.
 
 EXAMPLES
 --------

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
@@ -48,20 +48,21 @@ object Command extends App with DebugEnhancedLogging {
         .filterNot(_.startsWith("#"))
       )
     lazy val outputDir = commandLine.outputDir()
-    lazy val strict = commandLine.strictMode()
     lazy val europeana = commandLine.europeana()
     lazy val printer = CsvRecord.printer(commandLine.logFile())
 
     val outputFormat = commandLine.outputFormat()
     (commandLine.transformation(), outputFormat) match {
+      case (ORIGINAL_VERSIONED, _) if !europeana =>
+        printer.apply(app.createExport(ids, outputDir, Options(SimpleDatasetFilter(), commandLine), outputFormat))
       case (SIMPLE, SIP) =>
-        printer.apply(app.createExport(ids, outputDir, strict, europeana, SimpleDatasetFilter(), outputFormat))
+        printer.apply(app.createExport(ids, outputDir, Options(SimpleDatasetFilter(), commandLine), outputFormat))
       case (SIMPLE, AIP) =>
-        printer.apply(app.createExport(ids, outputDir, strict, europeana, SimpleDatasetFilter(app.bagIndex), outputFormat))
+        printer.apply(app.createExport(ids, outputDir, Options(SimpleDatasetFilter(app.bagIndex), commandLine), outputFormat))
       case (THEMA, AIP) =>
-        printer.apply(app.createExport(ids, outputDir, strict, europeana, ThemaDatasetFilter(app.bagIndex), outputFormat))
+        printer.apply(app.createExport(ids, outputDir, Options(ThemaDatasetFilter(app.bagIndex), commandLine), outputFormat))
       case tuple =>
-        Failure(new NotImplementedError(s"$tuple not implemented"))
+        Failure(new NotImplementedError(s"$tuple/europeana==$europeana not implemented"))
     }
   }.map(msg => s"$msg, for details see ${ commandLine.logFile().toJava.getAbsolutePath }")
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/CsvRecord.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/CsvRecord.scala
@@ -25,21 +25,22 @@ import org.apache.commons.csv.{ CSVFormat, CSVPrinter }
 import scala.util.Try
 
 case class CsvRecord(easyDatasetId: DatasetId,
-                     packageUUID: UUID,
+                     packageUuid1: UUID,
+                     packageUuid2: Option[UUID],
                      doi: String,
                      depositor: Depositor,
                      transformationType: String,
                      comment: String,
                     ) {
   def print(implicit printer: CSVPrinter): Try[FeedBackMessage] = Try {
-    printer.printRecord(easyDatasetId, packageUUID, doi, depositor, transformationType, comment)
+    printer.printRecord(easyDatasetId, packageUuid1, packageUuid2.getOrElse(""), doi, depositor, transformationType, comment)
     comment
   }
 }
 
 object CsvRecord {
   val csvFormat: CSVFormat = CSVFormat.RFC4180
-    .withHeader("easyDatasetId", "uuid", "doi", "depositor", "transformationType", "comment")
+    .withHeader("easyDatasetId", "uuid1", "uuid2", "doi", "depositor", "transformationType", "comment")
     .withDelimiter(',')
     .withRecordSeparator('\n')
     .withAutoFlush(true)

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/CsvRecord.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/CsvRecord.scala
@@ -25,14 +25,14 @@ import org.apache.commons.csv.{ CSVFormat, CSVPrinter }
 import scala.util.Try
 
 case class CsvRecord(easyDatasetId: DatasetId,
-                     ipUUID: UUID,
+                     packageUUID: UUID,
                      doi: String,
                      depositor: Depositor,
                      transformationType: String,
                      comment: String,
                     ) {
   def print(implicit printer: CSVPrinter): Try[FeedBackMessage] = Try {
-    printer.printRecord(easyDatasetId, ipUUID, doi, depositor, transformationType, comment)
+    printer.printRecord(easyDatasetId, packageUUID, doi, depositor, transformationType, comment)
     comment
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DatasetInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DatasetInfo.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.fedoratobag
 
 case class DatasetInfo(

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DatasetInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DatasetInfo.scala
@@ -1,0 +1,10 @@
+package nl.knaw.dans.easy.fedoratobag
+
+case class DatasetInfo(
+                        maybeFilterViolations: Option[String],
+                        doi: String,
+                        depositor: Depositor,
+                        nextFileInfos: Seq[FileInfo],
+                      ){
+
+}

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -111,7 +111,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
     def copy(fileName: String, bag2: DansV0Bag) = {
       (bagDir1 / "metadata" / fileName)
         .inputStream
-        .map(addMetadataStreamTo(bag2, s"metadata/$fileName"))
+        .map(addMetadataStreamTo(bag2, fileName))
         .get
     }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -122,9 +122,11 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ <- copy("amd.xml", bag2)
       _ <- copy("dataset.xml", bag2)
       _ <- (bagDir1 / "metadata").list.toList
-        .filter(_.name.contains("_LICENSE."))
+        .filter(_.name.toLowerCase.contains("license"))
         .traverse(file => copy(file.name, bag2))
-      _ <- fileInfos.toList.traverse(addPayloadFileTo(bag2))
+      fileItems <- fileInfos.toList.traverse(addPayloadFileTo(bag2))
+      _ <- checkNotImplemented(fileItems, logger)
+      _ <- addXmlMetadataTo(bag2, "files.xml")(filesXml(fileItems))
       _ <- bag2.save
     } yield ()
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -199,7 +199,9 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
     if (!originalVersioning || allFileInfos.size == firstFileInfos.size)
       Seq[FileInfo]()
     else {
+      // firstFileInfos are files of the first dataset in other words all original files
       val notAccessibleOriginals = selectFileInfos(NOT_ACCESSIBLE, firstFileInfos).getOrElse(Seq.empty)
+      // all files minus not accessible originals -> accessible originals + the rest for the second dataset
       val nextFileInfos = allFileInfos.toSet &~ notAccessibleOriginals.toSet
       logger.debug(s"nextFileInfos = ${ nextFileInfos.map(_.path) }")
       nextFileInfos.toSeq

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -129,7 +129,6 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
         .filter(_.name.toLowerCase.contains("license"))
         .traverse(file => copy(file.name, bag2))
       fileItems <- datasetInfo.nextFileInfos.toList.traverse(addPayloadFileTo(bag2))
-      _ <- datasetInfo.nextFileInfos.toList.filterNot(_.path.toString.startsWith("orininal/")).traverse(verifyChecksum(bag2))
       _ <- checkNotImplemented(fileItems, logger)
       _ <- addXmlMetadataTo(bag2, "files.xml")(filesXml(fileItems))
       _ <- bag2.save
@@ -187,7 +186,6 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       allFileInfos <- fedoraIDs.filter(_.startsWith("easy-file:")).toList.traverse(getFileInfo)
       firstFileInfos <- selectFileInfos(options.firstFileFilter(emdXml), allFileInfos)
       firstBagFileItems <- firstFileInfos.traverse(addPayloadFileTo(bag))
-      _ <- firstFileInfos.traverse(verifyChecksum(bag))
       _ <- checkNotImplemented(firstBagFileItems, logger)
       _ <- addXmlMetadataTo(bag, "files.xml")(filesXml(firstBagFileItems))
       _ <- bag.save
@@ -275,12 +273,9 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
         .disseminateDatastream(fileInfo.fedoraFileId, streamId)
         .map(bag.addPayloadFile(_, fileInfo.path))
         .tried.flatten
+      _ <- fileInfo.contentDigest.map(validateChecksum(bag.baseDir / s"data/${ fileInfo.path }", bag, fileInfo.fedoraFileId))
+        .getOrElse(Success(logger.warn(s"No digest found for ${ fileInfo.fedoraFileId } path = ${ fileInfo.path }")))
     } yield fileItem
-  }.recoverWith { case e => Failure(new Exception(s"${ fileInfo.fedoraFileId } ${ e.getMessage }", e)) }
-
-  private def verifyChecksum(bag: DansV0Bag)( fileInfo: FileInfo) = {
-    fileInfo.contentDigest.map(validateChecksum(bag.baseDir / s"data/${ fileInfo.path }", bag, fileInfo.fedoraFileId))
-      .getOrElse(Success(logger.warn(s"No digest found for ${ fileInfo.fedoraFileId } path = ${ fileInfo.path }")))
   }
 
   private def validateChecksum(file: File, bag: DansV0Bag, fedoraFileId: String)(maybeDigest: Node) = Try {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -266,6 +266,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
   }
 
   private def addPayloadFileTo(bag: DansV0Bag)(fileInfo: FileInfo): Try[Node] = {
+    val file = bag.baseDir / s"data/${ fileInfo.path }"
     val streamId = "EASY_FILE"
     for {
       fileItem <- FileItem(fileInfo)
@@ -273,7 +274,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
         .disseminateDatastream(fileInfo.fedoraFileId, streamId)
         .map(bag.addPayloadFile(_, fileInfo.path))
         .tried.flatten
-      _ <- fileInfo.contentDigest.map(validateChecksum(bag.baseDir / s"data/${ fileInfo.path }", bag, fileInfo.fedoraFileId))
+      _ <- fileInfo.contentDigest.map(validateChecksum(file, bag, fileInfo.fedoraFileId))
         .getOrElse(Success(logger.warn(s"No digest found for ${ fileInfo.fedoraFileId } path = ${ fileInfo.path }")))
     } yield fileItem
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileFilterType.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileFilterType.scala
@@ -15,10 +15,6 @@
  */
 package nl.knaw.dans.easy.fedoratobag
 
-import nl.knaw.dans.pf.language.emd.EasyMetadata
-
-import scala.xml.{ Elem, Node }
-
 object FileFilterType extends Enumeration {
   type FileFilterType = Value
 
@@ -29,17 +25,4 @@ object FileFilterType extends Enumeration {
   val ORIGINAL_FILES: FileFilterType = Value("ORIGINAL_FILES")
   val ALL_BUT_ORIGINAL: FileFilterType = Value("ALL_BUT_ORIGINAL")
   // @formatter:on
-
-  private def isDCMI(node: Node) = node
-    .attribute("http://easy.dans.knaw.nl/easy/easymetadata/eas/", "scheme")
-    .exists(_.text == "DCMI")
-
-  def from(europeana: Boolean, emd: Node): FileFilterType = {
-    if (!europeana) ALL_FILES
-    else {
-      val dcmiType = (emd \ "type" \ "type").filter(isDCMI)
-      if (dcmiType.text.toLowerCase.trim == "text") LARGEST_PDF
-      else LARGEST_IMAGE
-    }
-  }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileFilterType.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileFilterType.scala
@@ -23,6 +23,6 @@ object FileFilterType extends Enumeration {
   val LARGEST_IMAGE: FileFilterType = Value("LARGEST_IMAGE")
   val ALL_FILES: FileFilterType = Value("ALL_FILES")
   val ORIGINAL_FILES: FileFilterType = Value("ORIGINAL_FILES")
-  val ALL_BUT_ORIGINAL: FileFilterType = Value("ALL_BUT_ORIGINAL")
+  val NOT_ACCESSIBLE: FileFilterType = Value("NOT_ACCESSIBLE")
   // @formatter:on
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.fedoratobag
+
+import nl.knaw.dans.easy.fedoratobag.FileFilterType._
+import nl.knaw.dans.easy.fedoratobag.TransformationType.ORIGINAL_VERSIONED
+import nl.knaw.dans.easy.fedoratobag.filter.DatasetFilter
+
+import scala.xml.Node
+
+/**
+ *
+ * @param datasetFilter      which datasets are allowed for export
+ * @param strict             if false: violation of the datasetFilter only cause a warning
+ * @param europeana          if true: export only the largest PDF or image
+ * @param originalVersioning if true: export two bags, the first with original files only;
+ *                           not in combination with europeana
+ */
+case class Options(datasetFilter: DatasetFilter,
+                   strict: Boolean = true,
+                   europeana: Boolean = false,
+                   originalVersioning: Boolean = false,
+                  ) {
+  private def isDCMI(node: Node) = node
+    .attribute("http://easy.dans.knaw.nl/easy/easymetadata/eas/", "scheme")
+    .exists(_.text == "DCMI")
+
+  def firstFileFilter(emd: Node): FileFilterType = {
+    if (originalVersioning) ORIGINAL_FILES
+    else if (!europeana) ALL_FILES
+         else {
+           val dcmiType = (emd \ "type" \ "type").filter(isDCMI)
+           if (dcmiType.text.toLowerCase.trim == "text") LARGEST_PDF
+           else LARGEST_IMAGE
+         }
+  }
+}
+object Options {
+  def apply(datasetFilter: DatasetFilter, commandLine: CommandLineOptions): Options = {
+    Options(
+      datasetFilter: DatasetFilter,
+      commandLine.strictMode(),
+      commandLine.europeana(),
+      originalVersioning = commandLine.transformation() == ORIGINAL_VERSIONED,
+    )
+  }
+}

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/TransformationType.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/TransformationType.scala
@@ -21,5 +21,6 @@ object TransformationType extends Enumeration {
   // @formatter:off
   val SIMPLE: TransformationType = Value("simple")
   val THEMA: TransformationType = Value("thematische-collectie")
+  val ORIGINAL_VERSIONED: TransformationType = Value("original-versioned")
   // @formatter:on
 }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -60,9 +60,9 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     Map(
       "easy-discipline:77" -> audienceFoXML("easy-discipline:77", "D13200"),
       "easy-dataset:17" -> XML.loadFile((sampleFoXML / "DepositApi.xml").toJava),
-      "easy-file:35" -> fileFoXml(),
-      "easy-file:36" -> fileFoXml(id = 36, location = "x", accessibleTo = "ANONYMOUS"),
-      "easy-file:37" -> fileFoXml(id = 37, accessibleTo = "NONE", name="b.txt"),
+      "easy-file:35" -> fileFoXml(digest = digests("acabadabra")),
+      "easy-file:36" -> fileFoXml(id = 36, location = "x", accessibleTo = "ANONYMOUS", digest = digests("rabarbera")),
+      "easy-file:37" -> fileFoXml(id = 37, accessibleTo = "NONE", name = "b.txt", digest = digests("barbapappa")),
     ).foreach { case (id, xml) =>
       (app.fedoraProvider.loadFoXml(_: String)) expects id once() returning Success(xml)
     }
@@ -157,14 +157,14 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     Map(
       "easy-discipline:6" -> audienceFoXML("easy-discipline:6", "D35400"),
       "easy-dataset:13" -> XML.loadFile((sampleFoXML / "streaming.xml").toJava),
-      "easy-file:35" -> fileFoXml(),
+      "easy-file:35" -> fileFoXml(digest = digests("barbapappa")),
     ).foreach { case (id, xml) =>
       (app.fedoraProvider.loadFoXml(_: String)) expects id once() returning Success(xml)
     }
     (app.fedoraProvider.disseminateDatastream(_: String, _: String)) expects(
       "easy-file:35",
       "EASY_FILE"
-    ) once() returning managed("barbapapa".inputStream)
+    ) once() returning managed("barbapappa".inputStream)
     (app.fedoraProvider.getSubordinates(_: String)) expects "easy-dataset:13" once() returning
       Success(Seq("easy-file:35"))
 
@@ -227,16 +227,16 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val foXMLs = Map(
       "easy-dataset:13" -> XML.loadFile((sampleFoXML / "streaming.xml").toJava),
       "easy-discipline:6" -> audienceFoXML("easy-discipline:6", "D35400"),
-      "easy-file:1" -> fileFoXml(id = 1, name = "a.txt"),
-      "easy-file:2" -> fileFoXml(id = 2, name = "b.txt"),
-      "easy-file:3" -> fileFoXml(id = 3, name = "c.txt"),
+      "easy-file:1" -> fileFoXml(id = 1, name = "a.txt", digest = digests("lalala")),
+      "easy-file:2" -> fileFoXml(id = 2, name = "b.txt", digest = digests("lalala")),
+      "easy-file:3" -> fileFoXml(id = 3, name = "c.txt", digest = digests("lalala")),
     )
     foXMLs.foreach { case (id, xml) =>
       (app.fedoraProvider.loadFoXml(_: String)) expects id once() returning Success(xml)
     }
     Seq("easy-file:1", "easy-file:2", "easy-file:3").foreach { id =>
       (app.fedoraProvider.disseminateDatastream(_: String, _: String)
-        ) expects(id, "EASY_FILE") once() returning managed("blablabla".inputStream)
+        ) expects(id, "EASY_FILE") once() returning managed("lalala".inputStream)
     }
 
     // end of mocking
@@ -256,17 +256,17 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val foXMLs = Map(
       "easy-dataset:13" -> XML.loadFile((sampleFoXML / "streaming.xml").toJava),
       "easy-discipline:6" -> audienceFoXML("easy-discipline:6", "D35400"),
-      "easy-file:1" -> fileFoXml(id = 1, name = "b.png", mimeType = "image/png", size = 10, accessibleTo = "ANONYMOUS"),
-      "easy-file:2" -> fileFoXml(id = 2, name = "c.png", mimeType = "image/png", size = 20, accessibleTo = "ANONYMOUS"),
-      "easy-file:3" -> fileFoXml(id = 3, name = "d.png", mimeType = "image/png", size = 15, accessibleTo = "ANONYMOUS"),
-      "easy-file:4" -> fileFoXml(id = 4, name = "e.pdf", mimeType = "application/pdf", size = 15),
-      "easy-file:5" -> fileFoXml(id = 5, name = "a.txt"),
+      "easy-file:1" -> fileFoXml(id = 1, name = "b.png", mimeType = "image/png", size = 10, accessibleTo = "ANONYMOUS", digest = digests("lalala")),
+      "easy-file:2" -> fileFoXml(id = 2, name = "c.png", mimeType = "image/png", size = 20, accessibleTo = "ANONYMOUS", digest = digests("lalala")),
+      "easy-file:3" -> fileFoXml(id = 3, name = "d.png", mimeType = "image/png", size = 15, accessibleTo = "ANONYMOUS", digest = digests("lalala")),
+      "easy-file:4" -> fileFoXml(id = 4, name = "e.pdf", mimeType = "application/pdf", size = 15, digest = digests("lalala")),
+      "easy-file:5" -> fileFoXml(id = 5, name = "a.txt", digest = digests("lalala")),
     )
     foXMLs.foreach { case (id, xml) =>
       (app.fedoraProvider.loadFoXml(_: String)) expects id once() returning Success(xml)
     }
     (app.fedoraProvider.disseminateDatastream(_: String, _: String)
-      ) expects("easy-file:2", "EASY_FILE") once() returning managed("blablabla".inputStream)
+      ) expects("easy-file:2", "EASY_FILE") once() returning managed("lalala".inputStream)
 
     // end of mocking
 
@@ -285,16 +285,16 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
       "easy-dataset:13" -> XML.loadFile((sampleFoXML / "streaming.xml").toJava),
       "easy-discipline:6" -> audienceFoXML("easy-discipline:6", "D35400"),
       "easy-file:1" -> fileFoXml(id = 1, name = "a.txt"),
-      "easy-file:2" -> fileFoXml(id = 2, name = "b.pdf", mimeType = "application/pdf", size = 10, accessibleTo = "ANONYMOUS"),
-      "easy-file:3" -> fileFoXml(id = 3, name = "c.pdf", mimeType = "application/pdf", size = 20, accessibleTo = "ANONYMOUS"),
-      "easy-file:4" -> fileFoXml(id = 4, name = "d.pdf", mimeType = "application/pdf", size = 15, accessibleTo = "ANONYMOUS"),
+      "easy-file:2" -> fileFoXml(id = 2, name = "b.pdf", mimeType = "application/pdf", size = 10, accessibleTo = "ANONYMOUS", digest = digests("lalala")),
+      "easy-file:3" -> fileFoXml(id = 3, name = "c.pdf", mimeType = "application/pdf", size = 20, accessibleTo = "ANONYMOUS", digest = digests("lalala")),
+      "easy-file:4" -> fileFoXml(id = 4, name = "d.pdf", mimeType = "application/pdf", size = 15, accessibleTo = "ANONYMOUS", digest = digests("lalala")),
       "easy-file:5" -> fileFoXml(id = 5, name = "e.png", mimeType = "image/png"),
     )
     foXMLs.foreach { case (id, xml) =>
       (app.fedoraProvider.loadFoXml(_: String)) expects id once() returning Success(xml)
     }
     (app.fedoraProvider.disseminateDatastream(_: String, _: String)
-      ) expects("easy-file:3", "EASY_FILE") once() returning managed("blablabla".inputStream)
+      ) expects("easy-file:3", "EASY_FILE") once() returning managed("lalala".inputStream)
 
     // end of mocking
 
@@ -312,18 +312,18 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val foXMLs = Map(
       "easy-dataset:13" -> XML.loadFile((sampleFoXML / "streaming.xml").toJava),
       "easy-discipline:6" -> audienceFoXML("easy-discipline:6", "D35400"),
-      "easy-file:1" -> fileFoXml(id = 1, name = "a.txt", location = "x"), // default: original
-      "easy-file:2" -> fileFoXml(id = 2, name = "b.pdf", mimeType = "application/pdf", size = 10, accessibleTo = "ANONYMOUS"),
-      "easy-file:3" -> fileFoXml(id = 3, name = "c.pdf", mimeType = "application/pdf", size = 20, accessibleTo = "ANONYMOUS"),
-      "easy-file:4" -> fileFoXml(id = 4, name = "d.pdf", mimeType = "application/pdf", size = 15, accessibleTo = "NONE"),
-      "easy-file:5" -> fileFoXml(id = 5, name = "e.png", mimeType = "image/png", size = 15, location = "x"),
+      "easy-file:1" -> fileFoXml(id = 1, name = "a.txt", location = "x", digest = digests("lalala")), // default: original
+      "easy-file:2" -> fileFoXml(id = 2, name = "b.pdf", mimeType = "application/pdf", size = 10, accessibleTo = "ANONYMOUS", digest = digests("lalala")),
+      "easy-file:3" -> fileFoXml(id = 3, name = "c.pdf", mimeType = "application/pdf", size = 20, accessibleTo = "ANONYMOUS", digest = digests("lalala")),
+      "easy-file:4" -> fileFoXml(id = 4, name = "d.pdf", mimeType = "application/pdf", size = 15, accessibleTo = "NONE", digest = digests("lalala")),
+      "easy-file:5" -> fileFoXml(id = 5, name = "e.png", mimeType = "image/png", size = 15, location = "x", digest = digests("lalala")),
     )
     foXMLs.foreach { case (id, xml) =>
       (app.fedoraProvider.loadFoXml(_: String)) expects id once() returning Success(xml)
     }
     Seq(2, 3, 4).foreach(i =>
       (app.fedoraProvider.disseminateDatastream(_: String, _: String)
-        ) expects(s"easy-file:$i", "EASY_FILE") once() returning managed("blablabla".inputStream)
+        ) expects(s"easy-file:$i", "EASY_FILE") once() returning managed("lalala".inputStream)
     )
     // end of mocking
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -49,7 +49,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     // make almost private methods available for tests
 
-    override def createFirstBag(datasetId: DatasetId, bagDir: File, options: Options): Try[(Seq[FileInfo], CsvRecord)] =
+    override def createFirstBag(datasetId: DatasetId, bagDir: File, options: Options): Try[DatasetInfo] =
       super.createFirstBag(datasetId, bagDir, options)
   }
 
@@ -77,7 +77,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     val uuid = UUID.randomUUID
     app.createFirstBag("easy-dataset:17", testDir / "bags" / uuid.toString, Options(app.filter)) shouldBe
-      Success((Seq.empty, CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "simple", "OK")))
+      Success(DatasetInfo(None, "10.17026/test-Iiib-z9p-4ywa", "user001", Seq.empty))
 
     // post conditions
 
@@ -169,7 +169,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
     app.createFirstBag("easy-dataset:13", bagDir, Options(app.filter)) shouldBe
-      Success((Seq.empty, CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", "simple", "OK")))
+      Success(DatasetInfo(None, "10.17026/mocked-Iiib-z9p-4ywa", "user001", Seq.empty))
 
     // post conditions
 
@@ -325,7 +325,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
     app.createFirstBag("easy-dataset:13", bagDir, Options(app.filter, originalVersioning = true))
-      .map(_._1.map(_.path.toString).sortBy(identity)) shouldBe
+      .map(_.nextFileInfos.map(_.path.toString).sortBy(identity)) shouldBe
       Success(Vector("original/b.pdf", "original/c.pdf", "x/a.txt", "x/e.png"))
 
     (bagDir / "data").listRecursively.toList.map(_.name) should

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -23,7 +23,7 @@ import javax.naming.directory.{ BasicAttributes, SearchControls, SearchResult }
 import javax.naming.ldap.InitialLdapContext
 import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.fedoratobag.FileFilterType._
-import nl.knaw.dans.easy.fedoratobag.filter.{ BagIndex, DatasetFilter, InvalidTransformationException, SimpleDatasetFilter }
+import nl.knaw.dans.easy.fedoratobag.filter.{ BagIndex, InvalidTransformationException, SimpleDatasetFilter }
 import nl.knaw.dans.easy.fedoratobag.fixture._
 import org.scalamock.scalatest.MockFactory
 import resource.managed
@@ -51,8 +51,8 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     // make almost private methods available for tests
 
-    override def createBag(datasetId: DatasetId, bagDir: File, strict: Boolean, europeana: Boolean, datasetFilter: DatasetFilter): Try[CsvRecord] =
-      super.createBag(datasetId, bagDir, strict, europeana, datasetFilter)
+    override def createBag(datasetId: DatasetId, bagDir: File, options: Options): Try[CsvRecord] =
+      super.createBag(datasetId, bagDir, options)
 
     override def addPayloads(bag: DansV0Bag, fileFilterType: FileFilterType, fileIds: Seq[String]): Try[List[Node]] =
       super.addPayloads(bag, fileFilterType, fileIds)
@@ -81,7 +81,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val uuid = UUID.randomUUID
-    app.createBag("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true, europeana = false, app.filter) shouldBe
+    app.createBag("easy-dataset:17", testDir / "bags" / uuid.toString, Options(app.filter)) shouldBe
       Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "simple", "OK"))
 
     // post conditions
@@ -117,7 +117,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
-    app.createBag("easy-dataset:17", bagDir, strict = false, europeana = false, app.filter) shouldBe
+    app.createBag("easy-dataset:17", bagDir, Options(app.filter, strict = false)) shouldBe
       Failure(NoPayloadFilesException())
 
     // post conditions
@@ -146,7 +146,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
-    app.createBag("easy-dataset:17", bagDir, strict = true, europeana = false, app.filter) should matchPattern {
+    app.createBag("easy-dataset:17", bagDir, Options(app.filter)) should matchPattern {
       case Failure(_: InvalidTransformationException) =>
     }
     (testDir / "bags") shouldNot exist
@@ -173,7 +173,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
-    app.createBag("easy-dataset:13", bagDir, strict = true, europeana = false, app.filter) shouldBe
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter)) shouldBe
       Success(CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", "simple", "OK"))
 
     // post conditions
@@ -215,7 +215,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    app.createBag("easy-dataset:13", bagDir, strict = true, europeana = false, app.filter) should matchPattern {
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter)) should matchPattern {
       case Failure(e) if e.getMessage == "easy-file:35 <visibleTo> not found" =>
     }
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.fedoratobag
 
-import java.io.StringWriter
+import java.io.{ IOException, StringWriter }
 import java.util.UUID
 
 import better.files.{ File, _ }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -311,7 +311,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
       "easy-file:1" -> fileFoXml(id = 1, name = "a.txt", location = "x"), // default: original
       "easy-file:2" -> fileFoXml(id = 2, name = "b.pdf", mimeType = "application/pdf", size = 10, accessibleTo = "ANONYMOUS"),
       "easy-file:3" -> fileFoXml(id = 3, name = "c.pdf", mimeType = "application/pdf", size = 20, accessibleTo = "ANONYMOUS"),
-      "easy-file:4" -> fileFoXml(id = 4, name = "d.pdf", mimeType = "application/pdf", size = 15, accessibleTo = "ANONYMOUS"),
+      "easy-file:4" -> fileFoXml(id = 4, name = "d.pdf", mimeType = "application/pdf", size = 15, accessibleTo = "NONE"),
       "easy-file:5" -> fileFoXml(id = 5, name = "e.png", mimeType = "image/png", size = 15, location = "x"),
     )
     foXMLs.foreach { case (id, xml) =>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
@@ -22,7 +22,7 @@ import better.files.File
 import com.yourmediashelf.fedora.client.FedoraClientException
 import javax.naming.ldap.InitialLdapContext
 import nl.knaw.dans.easy.fedoratobag.OutputFormat.{ AIP, SIP }
-import nl.knaw.dans.easy.fedoratobag.filter.{ BagIndex, DatasetFilter, InvalidTransformationException, SimpleDatasetFilter }
+import nl.knaw.dans.easy.fedoratobag.filter.{ BagIndex, InvalidTransformationException, SimpleDatasetFilter }
 import nl.knaw.dans.easy.fedoratobag.fixture._
 import org.scalamock.scalatest.MockFactory
 
@@ -47,7 +47,7 @@ class CreateExportSpec extends TestSupportFixture with FileFoXmlSupport with Bag
     val filter: SimpleDatasetFilter = SimpleDatasetFilter(bagIndex)
 
     /** mocks the method called by the method under test */
-    override def createBag(datasetId: DatasetId, outputDir: File, strict: Boolean, europeana: Boolean, datasetFilter: DatasetFilter): Try[CsvRecord] = {
+    override def createBag(datasetId: DatasetId, outputDir: File, options: Options): Try[CsvRecord] = {
       outputDir.parent.createDirectories()
       datasetId match {
         case _ if datasetId.startsWith("fatal") =>
@@ -73,7 +73,7 @@ class CreateExportSpec extends TestSupportFixture with FileFoXmlSupport with Bag
 
     // end of mocking
 
-    app.createExport(ids, outputDir, strict = true, europeana = false, SimpleDatasetFilter(), SIP)(printer) shouldBe
+    app.createExport(ids, outputDir, Options(SimpleDatasetFilter()), SIP)(printer) shouldBe
       Success("no fedora/IO errors")
 
     // two directories with one entry each
@@ -93,7 +93,7 @@ class CreateExportSpec extends TestSupportFixture with FileFoXmlSupport with Bag
 
     // end of mocking
 
-    app.createExport(ids, outputDir, strict = true, europeana = false, app.filter, AIP)(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
+    app.createExport(ids, outputDir, Options(app.filter), AIP)(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
 
     // post conditions
 
@@ -114,7 +114,7 @@ class CreateExportSpec extends TestSupportFixture with FileFoXmlSupport with Bag
 
     // end of mocking
 
-    app.createExport(ids, outputDir, strict = true, europeana = false, app.filter, AIP)(CsvRecord.csvFormat.print(sw)) should matchPattern {
+    app.createExport(ids, outputDir, Options(app.filter), AIP)(CsvRecord.csvFormat.print(sw)) should matchPattern {
       case Failure(t) if t.getMessage == "mocked exception" =>
     }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
@@ -47,7 +47,7 @@ class CreateExportSpec extends TestSupportFixture with FileFoXmlSupport with Bag
     val filter: SimpleDatasetFilter = SimpleDatasetFilter(bagIndex)
 
     /** mocks the method called by the method under test */
-    override def createBag(datasetId: DatasetId, outputDir: File, options: Options): Try[CsvRecord] = {
+    override def createFirstBag(datasetId: DatasetId, outputDir: File, options: Options): Try[(Seq[FileInfo],CsvRecord)] = {
       outputDir.parent.createDirectories()
       datasetId match {
         case _ if datasetId.startsWith("fatal") =>
@@ -60,7 +60,7 @@ class CreateExportSpec extends TestSupportFixture with FileFoXmlSupport with Bag
           Failure(new Exception(datasetId))
         case _ =>
           outputDir.createFile().writeText(datasetId)
-          Success(CsvRecord(datasetId, UUID.randomUUID(), doi = "testDOI", depositor = "testUser", transformationType = "simple", comment = "OK"))
+          Success((Seq.empty,CsvRecord(datasetId, UUID.randomUUID(), doi = "testDOI", depositor = "testUser", transformationType = "simple", comment = "OK")))
       }
     }
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
@@ -16,7 +16,6 @@
 package nl.knaw.dans.easy.fedoratobag
 
 import java.io.StringWriter
-import java.util.UUID
 
 import better.files.File
 import com.yourmediashelf.fedora.client.FedoraClientException
@@ -47,7 +46,7 @@ class CreateExportSpec extends TestSupportFixture with FileFoXmlSupport with Bag
     val filter: SimpleDatasetFilter = SimpleDatasetFilter(bagIndex)
 
     /** mocks the method called by the method under test */
-    override def createFirstBag(datasetId: DatasetId, outputDir: File, options: Options): Try[(Seq[FileInfo],CsvRecord)] = {
+    override def createFirstBag(datasetId: DatasetId, outputDir: File, options: Options): Try[DatasetInfo] = {
       outputDir.parent.createDirectories()
       datasetId match {
         case _ if datasetId.startsWith("fatal") =>
@@ -60,7 +59,7 @@ class CreateExportSpec extends TestSupportFixture with FileFoXmlSupport with Bag
           Failure(new Exception(datasetId))
         case _ =>
           outputDir.createFile().writeText(datasetId)
-          Success((Seq.empty,CsvRecord(datasetId, UUID.randomUUID(), doi = "testDOI", depositor = "testUser", transformationType = "simple", comment = "OK")))
+          Success(DatasetInfo(None, doi = "testDOI", depositor = "testUser", Seq.empty))
       }
     }
   }
@@ -104,7 +103,7 @@ class CreateExportSpec extends TestSupportFixture with FileFoXmlSupport with Bag
 
     val csvContent = sw.toString
     csvContent should (fullyMatch regex
-      """easyDatasetId,uuid,doi,depositor,transformationType,comment
+      """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
         |success:1,.*,testDOI,testUser,simple,OK
         |success:2,.*,testDOI,testUser,simple,OK
         |""".stripMargin
@@ -131,7 +130,7 @@ class CreateExportSpec extends TestSupportFixture with FileFoXmlSupport with Bag
 
     val csvContent = sw.toString
     csvContent should (fullyMatch regex
-      """easyDatasetId,uuid,doi,depositor,transformationType,comment
+      """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
         |success:1,.*,testDOI,testUser,simple,OK
         |failure:2,.*,,,simple,FAILED: java.lang.Exception: failure:2
         |notSimple:3,.*,,,simple,FAILED: .*InvalidTransformationException: mocked

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/FileFoXmlSupport.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/FileFoXmlSupport.scala
@@ -19,12 +19,20 @@ import scala.xml.Elem
 
 trait FileFoXmlSupport {
 
+  val digests = Map(
+    "acabadabra" -> "4efe30290dd3d4498d66ef569c858cae1cfdb484",
+    "lalala" -> "df2efa060e335f97628ca39c9fef5469ab3cb837",
+    "rabarbera" -> "1f630a1c539661e70072ea791da18ec600062b93",
+    "barbapappa" -> "233e316356c2f4213eb0bf7ca26eec925a3cf214",
+  )
+
   def fileFoXml(id: Int = 35,
                 location: String = "original",
                 name: String = "something.txt",
                 mimeType: String = "text/plain",
                 size: Long = 30,
                 accessibleTo: String = "RESTRICTED_REQUEST",
+                digest: String = "dd466d19481a28ba8577e7b3f029e496027a3309"
                ): Elem = {
     <foxml:digitalObject VERSION="1.1" PID={s"easy-file:$id"}
                      xmlns:foxml="info:fedora/fedora-system:def/foxml#"
@@ -39,8 +47,8 @@ trait FileFoXmlSupport {
       </foxml:objectProperties>
       <foxml:datastream ID="EASY_FILE" STATE="A" CONTROL_GROUP="M" VERSIONABLE="false">
           <foxml:datastreamVersion ID="EASY_FILE.0" LABEL="" CREATED="2020-03-17T10:24:17.542Z" MIMETYPE={ mimeType } SIZE={ size.toString }>
-              <foxml:contentDigest TYPE="SHA-1" DIGEST="dd466d19481a28ba8577e7b3f029e496027a3309"/>
-              <foxml:contentLocation TYPE="INTERNAL_ID" REF={s"easy-file:$id+EASY_FILE+EASY_FILE.0"}/>
+              <foxml:contentDigest TYPE="SHA-1" DIGEST={ digest }/>
+              <foxml:contentLocation TYPE="INTERNAL_ID" REF={ s"easy-file:$id+EASY_FILE+EASY_FILE.0" }/>
           </foxml:datastreamVersion>
       </foxml:datastream>
       <foxml:datastream ID="EASY_FILE_METADATA" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">


### PR DESCRIPTION
Fixes DD-208: Versioning with only original files in first bag

#### When applied it will...
* [x] not calculate the checksum twice of accessible original files
* [x] have `EASY-User-Account` in `bag-info.txt` of both bags
* 

#### Where should the reviewer @DANS-KNAW/easy @DANS-KNAW/dataversedans start?

#### How should this be manually tested?

https://github.com/DANS-KNAW/easy-fedora-to-bag/blob/fb6a7ac6ea3fcabb39262fd1711a300359dec2bc/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala#L58
should produce (with other UUIDs):
```
target/test/AppSpec/output
|-- 448501b8-bb0c-4f52-9b0f-91ffc17ee1f8
|   `-- 15438c3f-4088-4f5c-b6de-3a20e8b27196
|       |-- bag-info.txt
|       |-- bagit.txt
|       |-- data
|       |   |-- original
|       |   |   `-- something.txt
|       |   `-- x
|       |       `-- something.txt
|       |-- manifest-sha1.txt
|       |-- metadata
|       |   |-- amd.xml
|       |   |-- dataset.xml
|       |   |-- emd.xml
|       |   |-- files.xml
|       |   `-- license.pdf
|       `-- tagmanifest-sha1.txt
`-- ed6bbd1e-1c3a-47ec-bdbb-1c458d45daba
    `-- 4019e876-1e50-4588-9552-b2bf57b03b59
        |-- bag-info.txt
        |-- bagit.txt
        |-- data
        |   `-- original
        |       |-- b.txt
        |       `-- something.txt
        |-- manifest-sha1.txt
        |-- metadata
        |   |-- amd.xml
        |   |-- dataset.xml
        |   |-- depositor-info
        |   |   |-- agreements.xml
        |   |   |-- depositor-agreement.pdf
        |   |   `-- message-from-depositor.txt
        |   |-- emd.xml
        |   |-- files.xml
        |   |-- license.pdf
        |   `-- original
        |       |-- dataset.xml
        |       `-- files.xml
        `-- tagmanifest-sha1.txt
```

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
