### PR TITLE
DD-255: doi like urn via bag-info.txt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ ARGUMENTS
     
     trailing arguments:
      transformation (required)   The type of transformation used: simple, thematische-collectie,
-                                 original-versioned.
+                                 original-versioned, fedora-versioned.
 
 EXAMPLES
 --------

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
@@ -53,6 +53,8 @@ object Command extends App with DebugEnhancedLogging {
 
     val outputFormat = commandLine.outputFormat()
     (commandLine.transformation(), outputFormat) match {
+      case (FEDORA_VERSIONED, SIP) if !europeana =>
+        ??? // TODO collect chains then call createExport in proper order DD-210
       case (ORIGINAL_VERSIONED, SIP) if !europeana =>
         printer.apply(app.createExport(ids, outputDir, Options(SimpleDatasetFilter(), commandLine), outputFormat))
       case (SIMPLE, SIP) =>

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DatasetInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DatasetInfo.scala
@@ -15,11 +15,10 @@
  */
 package nl.knaw.dans.easy.fedoratobag
 
-case class DatasetInfo(
-                        maybeFilterViolations: Option[String],
-                        doi: String,
-                        depositor: Depositor,
-                        nextFileInfos: Seq[FileInfo],
-                      ){
-
+case class DatasetInfo(maybeFilterViolations: Option[String],
+                       doi: String,
+                       urn: String,
+                       depositor: Depositor,
+                       nextFileInfos: Seq[FileInfo],
+                      ) {
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/TransformationType.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/TransformationType.scala
@@ -22,5 +22,6 @@ object TransformationType extends Enumeration {
   val SIMPLE: TransformationType = Value("simple")
   val THEMA: TransformationType = Value("thematische-collectie")
   val ORIGINAL_VERSIONED: TransformationType = Value("original-versioned")
+  val FEDORA_VERSIONED: TransformationType = Value("fedora-versioned")
   // @formatter:on
 }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -221,7 +221,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
     app.createFirstBag("easy-dataset:13", bagDir, Options(app.filter)) shouldBe
-      Success(DatasetInfo(None, "10.17026/mocked-Iiib-z9p-4ywa", "user001", Seq.empty))
+      Success(DatasetInfo(None, "10.17026/mocked-Iiib-z9p-4ywa","", "user001", Seq.empty))
 
     // post conditions
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
@@ -59,7 +59,7 @@ class CreateExportSpec extends TestSupportFixture with FileFoXmlSupport with Bag
           Failure(new Exception(datasetId))
         case _ =>
           outputDir.createFile().writeText(datasetId)
-          Success(DatasetInfo(None, doi = "testDOI", depositor = "testUser", Seq.empty))
+          Success(DatasetInfo(None, doi = "testDOI", urn = "testURN", depositor = "testUser", Seq.empty))
       }
     }
   }


### PR DESCRIPTION
Fixes DD-255: doi like urn via bag-info.txt

#### When applied it will...
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

See related PR

#### Related pull requests on github

https://github.com/DANS-KNAW/easy-convert-bag-to-deposit/pull/10