### PR TITLE
DD-210 fedora versioned - export the result of a dry run

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
@@ -19,13 +19,13 @@ import better.files.File
 import nl.knaw.dans.easy.fedoratobag.OutputFormat._
 import nl.knaw.dans.easy.fedoratobag.TransformationType._
 import nl.knaw.dans.easy.fedoratobag.filter._
-import nl.knaw.dans.easy.fedoratobag.versions.Versions
+import nl.knaw.dans.easy.fedoratobag.versions.FedoraVersions
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.language.reflectiveCalls
+import scala.util.Try
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Try }
 
 object Command extends App with DebugEnhancedLogging {
   type FeedBackMessage = String
@@ -42,36 +42,44 @@ object Command extends App with DebugEnhancedLogging {
     .doIfFailure { case NonFatal(e) => println(s"FAILED: ${ e.getMessage }") }
 
   private def runSubcommand(app: EasyFedoraToBagApp): Try[FeedBackMessage] = {
-    lazy val ids = commandLine
+    lazy val isAip = commandLine.outputFormat() == AIP
+    Try(commandLine.transformation() match {
+      case FEDORA_VERSIONED if !commandLine.europeana() && !isAip => FedoraVersionedFilter()
+      case ORIGINAL_VERSIONED if !isAip => SimpleDatasetFilter()
+      case THEMA if isAip => ThemaDatasetFilter(app.bagIndex)
+      case SIMPLE if isAip => SimpleDatasetFilter(app.bagIndex)
+      case SIMPLE => SimpleDatasetFilter()
+      case _ => throw new NotImplementedError(s"${ commandLine.args } not implemented")
+    }).flatMap { datasetFilter =>
+      if (!commandLine.outputDir.isSupplied)
+        dryRunFedoraVersioned(app)
+      else runExport(app, datasetFilter)
+    }
+  }.map(msg => s"$msg, for details see ${ commandLine.logFile().toJava.getAbsolutePath }")
+
+  private def dryRunFedoraVersioned(app: EasyFedoraToBagApp) = {
+    FedoraVersions(app.fedoraProvider)
+      .findChains(datasetIds).map { families =>
+      commandLine.logFile().printLines(families.map(_.mkString(",")))
+      s"DRY RUN --- produced IDs of bag sequences per CSV line"
+    }
+  }
+
+  private def runExport(app: EasyFedoraToBagApp, datasetFilter: SimpleDatasetFilter) = {
+    val options = Options(datasetFilter, commandLine.transformation(), commandLine.strictMode(), commandLine.europeana())
+    val printer = CsvRecord.printer(commandLine.logFile())
+    if (commandLine.transformation() == FEDORA_VERSIONED)
+      printer.apply(app.createSequences(datasetIds, commandLine.outputDir(), options))
+    else printer.apply(app.createExport(datasetIds, commandLine.outputDir(), options, commandLine.outputFormat()))
+  }
+
+  private def datasetIds = {
+    commandLine
       .datasetId.map(Iterator(_))
-      .getOrElse(commandLine.inputFile()
+      .getOrElse(commandLine
+        .inputFile()
         .lineIterator
         .filterNot(_.startsWith("#"))
       )
-    lazy val outputDir = commandLine.outputDir()
-    lazy val europeana = commandLine.europeana()
-    lazy val outputFormat = commandLine.outputFormat()
-    lazy val printer = CsvRecord.printer(commandLine.logFile())
-    commandLine.transformation() match {
-      case FEDORA_VERSIONED if commandLine.outputDir.isSupplied =>
-        Failure(new NotImplementedError(s"only DRY RUN implemented for $FEDORA_VERSIONED"))
-      case FEDORA_VERSIONED if !europeana =>
-        new Versions() {
-          override val fedoraProvider: FedoraProvider = app.fedoraProvider
-        }.findChains(ids).map { families =>
-          commandLine.logFile().printLines(families.map(_.mkString(",")))
-          s"DRY RUN --- produced IDs of bag sequences per CSV line"
-        }
-      case ORIGINAL_VERSIONED if outputFormat == SIP && !europeana =>
-        printer.apply(app.createExport(ids, outputDir, Options(SimpleDatasetFilter(), commandLine), outputFormat))
-      case SIMPLE if outputFormat == SIP =>
-        printer.apply(app.createExport(ids, outputDir, Options(SimpleDatasetFilter(), commandLine), outputFormat))
-      case SIMPLE if outputFormat == AIP =>
-        printer.apply(app.createExport(ids, outputDir, Options(SimpleDatasetFilter(app.bagIndex), commandLine), outputFormat))
-      case THEMA if outputFormat == AIP =>
-        printer.apply(app.createExport(ids, outputDir, Options(ThemaDatasetFilter(app.bagIndex), commandLine), outputFormat))
-      case _ =>
-        Failure(new NotImplementedError(s"${ commandLine.args } not implemented"))
-    }
-  }.map(msg => s"$msg, for details see ${ commandLine.logFile().toJava.getAbsolutePath }")
+  }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
@@ -42,7 +42,7 @@ object Command extends App with DebugEnhancedLogging {
     .doIfFailure { case NonFatal(e) => println(s"FAILED: ${ e.getMessage }") }
 
   private def runSubcommand(app: EasyFedoraToBagApp): Try[FeedBackMessage] = {
-    lazy val isAip = commandLine.outputFormat() == AIP
+    lazy val isAip = commandLine.outputFormat.isSupplied && commandLine.outputFormat() == AIP
     Try(commandLine.transformation() match {
       case FEDORA_VERSIONED if !commandLine.europeana() && !isAip => FedoraVersionedFilter()
       case ORIGINAL_VERSIONED if !isAip => SimpleDatasetFilter()

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/CsvRecord.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/CsvRecord.scala
@@ -20,6 +20,7 @@ import java.util.UUID
 
 import better.files.{ Dispose, File }
 import nl.knaw.dans.easy.fedoratobag.Command.FeedBackMessage
+import nl.knaw.dans.easy.fedoratobag.TransformationType.ORIGINAL_VERSIONED
 import org.apache.commons.csv.{ CSVFormat, CSVPrinter }
 
 import scala.util.Try
@@ -49,5 +50,21 @@ object CsvRecord {
   def printer(file: File): Dispose[CSVPrinter] = {
     val writer = file.newFileWriter(append = true)
     new Dispose(csvFormat.print(writer))
+  }
+
+  def apply(datasetId: DatasetId, datasetInfo: DatasetInfo, uuid1: UUID, uuid2: Option[UUID], options: Options): CsvRecord = {
+    val violations = datasetInfo.maybeFilterViolations
+    val comment = if (uuid2.isEmpty && options.transformationType == ORIGINAL_VERSIONED)
+                    "No second bag. " + violations.mkString("")
+                  else violations.getOrElse("OK")
+    new CsvRecord(
+      datasetId,
+      uuid1,
+      uuid2,
+      datasetInfo.doi,
+      datasetInfo.depositor,
+      violations.map(_ => "not strict ").getOrElse("") + options.transformationType,
+      comment,
+    )
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/CsvRecord.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/CsvRecord.scala
@@ -54,16 +54,22 @@ object CsvRecord {
 
   def apply(datasetId: DatasetId, datasetInfo: DatasetInfo, uuid1: UUID, uuid2: Option[UUID], options: Options): CsvRecord = {
     val violations = datasetInfo.maybeFilterViolations
-    val comment = if (uuid2.isEmpty && options.transformationType == ORIGINAL_VERSIONED)
-                    "No second bag. " + violations.mkString("")
-                  else violations.getOrElse("OK")
+    val comment = if (violations.isEmpty) "OK"
+                  else violations.mkString("")
+    val typePrefix = violations.map(_ => "not strict ").getOrElse("")
+    val typeSuffix = uuid2.map(_ => "")
+      .getOrElse(
+        if (options.transformationType == ORIGINAL_VERSIONED)
+          " without second bag"
+        else ""
+      )
     new CsvRecord(
       datasetId,
       uuid1,
       uuid2,
       datasetInfo.doi,
       datasetInfo.depositor,
-      violations.map(_ => "not strict ").getOrElse("") + options.transformationType,
+      typePrefix + options.transformationType + typeSuffix,
       comment,
     )
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DatasetInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DatasetInfo.scala
@@ -19,5 +19,5 @@ case class DatasetInfo(maybeFilterViolations: Option[String],
                        doi: String,
                        urn: String,
                        depositor: Depositor,
-                       nextFileInfos: Seq[FileInfo],
+                       nextFileInfos: Seq[FileInfo] = Seq.empty,
                       )

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -89,10 +89,11 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
 
     lines.map { line =>
       val datasetIds = line.split(",")
-      datasetIds
+      val triedUnit = datasetIds
         .headOption
         .map(exportSequence(datasetIds.tail))
         .getOrElse(Success(()))
+      recoverUnlessFatal(triedUnit,printer,datasetIds.head,null)
     }.failFastOr(Success("no fedora/IO errors"))
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -130,7 +130,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
     }.recoverWith {
       case t: FedoraClientException if t.getStatus != 404 => Failure(t)
       case t: IOException => Failure(t)
-      case t => CsvRecord(datasetId, packageUUID, None, doi = "", depositor = "", SIMPLE.toString, s"FAILED: $t")
+      case t => CsvRecord(datasetId, packageUUID, None, doi = "", depositor = "", "-", s"FAILED: $t")
         .print(printer)
         Success(())
     }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -28,7 +28,7 @@ import com.yourmediashelf.fedora.client.{ FedoraClient, FedoraClientException }
 import javax.naming.ldap.InitialLdapContext
 import nl.knaw.dans.bag.ChecksumAlgorithm
 import nl.knaw.dans.bag.v0.DansV0Bag
-import nl.knaw.dans.easy.fedoratobag.Command.FeedBackMessage
+import nl.knaw.dans.easy.fedoratobag.Command.{ FeedBackMessage, logger }
 import nl.knaw.dans.easy.fedoratobag.FileItem.{ checkNotImplemented, filesXml }
 import nl.knaw.dans.easy.fedoratobag.FoXml.{ getEmd, _ }
 import nl.knaw.dans.easy.fedoratobag.OutputFormat.OutputFormat
@@ -54,6 +54,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
   private val emdUnmarshaller = new EmdUnmarshaller(classOf[EasyMetadataImpl])
 
   def createSequences(lines: Iterator[String], outputDir: File, options: Options)(printer: CSVPrinter): Try[FeedBackMessage] = {
+    logger.info(options.toString)
 
     def exportBag(firstVersion: Option[VersionInfo], datasetId: DatasetId): Try[VersionInfo] = {
       val packageUUID = UUID.randomUUID
@@ -92,6 +93,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
 
   def createExport(input: Iterator[DatasetId], outputDir: File, options: Options, outputFormat: OutputFormat)
                   (printer: CSVPrinter): Try[FeedBackMessage] = input.map { datasetId =>
+    logger.info(options.toString)
 
     def bagDir(packageDir: File) = outputFormat match {
       case OutputFormat.AIP => packageDir

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -67,9 +67,9 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
         datasetInfo <- createBag(datasetId, packageDir / UUID.randomUUID.toString, options, firstVersion)
         _ <- movePackageAtomically(packageDir, outputDir)
         thisVersionInfo = VersionInfo(datasetInfo, packageUUID)
-        csv = firstVersion
-          .map(f => CsvRecord(datasetId, datasetInfo, f.packageId, Some(packageUUID), options))
-          .getOrElse(CsvRecord(datasetId, datasetInfo, packageUUID, None, options))
+        uuid1 = firstVersion.map(_.packageId).getOrElse(packageUUID)
+        uuid2 = firstVersion.map(_ => packageUUID)
+        csv = CsvRecord(datasetId, datasetInfo, uuid1, uuid2, options)
       } yield (thisVersionInfo, csv)
       errorHandling(tried.map(_._2), printer, datasetId, packageDir)
       tried.map(_._1)
@@ -169,7 +169,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
     } yield ()
   }
 
-  protected[EasyFedoraToBagApp] def createBag(datasetId: DatasetId, bagDir: File, options: Options, firstVersionInfo: Option[VersionInfo] = None): Try[DatasetInfo] = {
+  def createBag(datasetId: DatasetId, bagDir: File, options: Options, firstVersionInfo: Option[VersionInfo] = None): Try[DatasetInfo] = {
 
     def managedMetadataStream(foXml: Elem, streamId: String, bag: DansV0Bag, metadataFile: String) = {
       managedStreamLabel(foXml, streamId)

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -85,7 +85,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       val datasetIds = line.split(",")
       val triedUnit = datasetIds
         .headOption
-        .map(exportSequence(datasetIds.tail))
+        .map(exportSequence(datasetIds.drop(1)))
         .getOrElse(Success(()))
       errorHandling(triedUnit, printer, datasetIds.head, null)
     }.failFastOr(Success("no fedora/IO errors"))

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -80,15 +80,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       // the 2nd bag is moved first, thus a next process has a chance to stumble over a missing first bag in case of interrupts
       _ <- maybeBagDir2.map(_ => movePackageAtomically(packageDir2)).getOrElse(Success(()))
       _ <- movePackageAtomically(packageDir1)
-    } yield CsvRecord(
-      datasetId,
-      packageUuid1,
-      maybeBagDir2.map(_ => packageUuid2),
-      datasetInfo.doi,
-      datasetInfo.depositor,
-      transformationType = datasetInfo.maybeFilterViolations.map(_ => "not strict simple").getOrElse(SIMPLE.toString),
-      datasetInfo.maybeFilterViolations.getOrElse("OK"),
-    )
+    } yield CsvRecord(datasetId, datasetInfo, packageUuid1, maybeBagDir2.map(_ => packageUuid2), options)
     errorHandling(triedCsvRecord, printer, datasetId, packageDir1)
   }.failFastOr(Success("no fedora/IO errors"))
 
@@ -196,7 +188,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       doi = emd.getEmdIdentifier.getDansManagedDoi
       urn = getUrn(datasetId, emd)
       nextFileInfos = if (maybeFilterViolations.nonEmpty && options.strict) Seq.empty
-                      else getNextFileInfos(allFileInfos, firstFileInfos, options.originalVersioning)
+                      else getNextFileInfos(allFileInfos, firstFileInfos, options.transformationType == ORIGINAL_VERSIONED)
     } yield DatasetInfo(maybeFilterViolations, doi, urn, depositor, nextFileInfos)
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
@@ -46,13 +46,3 @@ case class Options(datasetFilter: DatasetFilter,
          }
   }
 }
-object Options {
-  def apply(datasetFilter: DatasetFilter, commandLine: CommandLineOptions): Options = {
-    Options(
-      datasetFilter,
-      commandLine.transformation(),
-      commandLine.strictMode(),
-      commandLine.europeana(),
-    )
-  }
-}

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.fedoratobag
 
-import nl.knaw.dans.easy.fedoratobag.TransformationType.ORIGINAL_VERSIONED
+import nl.knaw.dans.easy.fedoratobag.TransformationType.{ ORIGINAL_VERSIONED, SIMPLE, TransformationType }
 import nl.knaw.dans.easy.fedoratobag.filter.DatasetFilter
 import nl.knaw.dans.easy.fedoratobag.filter.FileFilterType._
 
@@ -23,23 +23,21 @@ import scala.xml.Node
 
 /**
  *
- * @param datasetFilter      which datasets are allowed for export
- * @param strict             if false: violation of the datasetFilter only cause a warning
- * @param europeana          if true: export only the largest PDF or image
- * @param originalVersioning if true: export two bags, the first with original files only;
- *                           not in combination with europeana
+ * @param datasetFilter which datasets are allowed for export
+ * @param strict        if false: violation of the datasetFilter only cause a warning
+ * @param europeana     if true: export only the largest PDF or image
  */
 case class Options(datasetFilter: DatasetFilter,
+                   transformationType: TransformationType = SIMPLE,
                    strict: Boolean = true,
                    europeana: Boolean = false,
-                   originalVersioning: Boolean = false,
                   ) {
   private def isDCMI(node: Node) = node
     .attribute("http://easy.dans.knaw.nl/easy/easymetadata/eas/", "scheme")
     .exists(_.text == "DCMI")
 
   def firstFileFilter(emd: Node): FileFilterType = {
-    if (originalVersioning) ORIGINAL_FILES
+    if (transformationType == ORIGINAL_VERSIONED) ORIGINAL_FILES
     else if (!europeana) ALL_FILES
          else {
            val dcmiType = (emd \ "type" \ "type").filter(isDCMI)
@@ -51,10 +49,10 @@ case class Options(datasetFilter: DatasetFilter,
 object Options {
   def apply(datasetFilter: DatasetFilter, commandLine: CommandLineOptions): Options = {
     Options(
-      datasetFilter: DatasetFilter,
+      datasetFilter,
+      commandLine.transformation(),
       commandLine.strictMode(),
       commandLine.europeana(),
-      originalVersioning = commandLine.transformation() == ORIGINAL_VERSIONED,
     )
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/VersionInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/VersionInfo.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.fedoratobag
 
 import java.util.UUID

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/VersionInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/VersionInfo.scala
@@ -1,0 +1,23 @@
+package nl.knaw.dans.easy.fedoratobag
+
+import java.util.UUID
+
+import nl.knaw.dans.bag.v0.DansV0Bag
+
+case class VersionInfo(
+                        doi: String,
+                        urn: String,
+                        packageId: UUID,
+                      ) {
+  def addVersionOf(bag: DansV0Bag): DansV0Bag = {
+    bag.withIsVersionOf(packageId)
+      // the following keys should match easy-fedora-to-bag
+      .addBagInfo("Base-DOI", doi)
+      .addBagInfo("Base-URN", urn)
+  }
+}
+object VersionInfo {
+  def apply(datasetInfo: DatasetInfo, packageID: UUID): VersionInfo = {
+    VersionInfo(datasetInfo.doi, datasetInfo.urn, packageID)
+  }
+}

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/DatasetFilter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/DatasetFilter.scala
@@ -40,7 +40,7 @@ trait DatasetFilter extends DebugEnhancedLogging {
     val violations = Seq(
       "1: DANS DOI" -> (if (maybeDoi.isEmpty) Seq("not found")
                         else Seq[String]()),
-      "2: has jump off" -> fedoraIDs.filter(_.startsWith("easy-jumpoff:")),
+      "2: has jump off" -> fedoraIDs.filter(_.startsWith("dans-jumpoff:")),
       "3: invalid title" -> Option(emd.getEmdTitle.getPreferredTitle)
         .filter(title => forbiddenTitle(title)).toSeq,
       invalidRightsKey -> findInvalidRights(emd),

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/FedoraVersionedFilter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/FedoraVersionedFilter.scala
@@ -17,6 +17,6 @@ package nl.knaw.dans.easy.fedoratobag.filter
 
 import scala.xml.Node
 
-case class SequenceFilter() extends SimpleDatasetFilter {
+case class FedoraVersionedFilter() extends SimpleDatasetFilter {
   override def findDansRelations(ddm: Node): Seq[Node] = Seq.empty
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/SequenceFilter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/SequenceFilter.scala
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.fedoratobag
+package nl.knaw.dans.easy.fedoratobag.filter
 
-case class DatasetInfo(maybeFilterViolations: Option[String],
-                       doi: String,
-                       urn: String,
-                       depositor: Depositor,
-                       nextFileInfos: Seq[FileInfo],
-                      )
+import scala.xml.Node
+
+case class SequenceFilter() extends SimpleDatasetFilter {
+  override def findDansRelations(ddm: Node): Seq[Node] = Seq.empty
+}

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
@@ -15,12 +15,13 @@
  */
 package nl.knaw.dans.easy.fedoratobag.versions
 
+import com.yourmediashelf.fedora.client.FedoraClientException
 import nl.knaw.dans.easy.fedoratobag.{ DatasetId, FedoraProvider }
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.collection.mutable
-import scala.util.{ Success, Try }
+import scala.util.{ Failure, Success, Try }
 import scala.xml.XML
 
 case class FedoraVersions(fedoraProvider: FedoraProvider) extends DebugEnhancedLogging {
@@ -41,7 +42,12 @@ case class FedoraVersions(fedoraProvider: FedoraProvider) extends DebugEnhancedL
       _ <- ids
         .withFilter(!collectedIds.contains(_))
         .map(findVersions)
-        .find(_.isFailure)
+        .filter{
+          case Failure(e: FedoraClientException) if e.getStatus == 404 =>
+            logger.error(e.getMessage)
+            false
+          case _ => true
+        }.find(_.isFailure)
         .getOrElse(Success(()))
       chains = families.map(_.toSeq
         .sortBy { case (_, date) => date }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
@@ -23,9 +23,8 @@ import scala.collection.mutable
 import scala.util.{ Success, Try }
 import scala.xml.XML
 
-abstract class Versions() extends DebugEnhancedLogging {
+case class FedoraVersions(fedoraProvider: FedoraProvider) extends DebugEnhancedLogging {
   val resolver: Resolver = Resolver()
-  val fedoraProvider: FedoraProvider
 
   /* a submission date for each ID */
   private type Family = mutable.Map[DatasetId, Long]

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -12,6 +12,6 @@
     </root>
 
     <!-- Set log level during test with system property, e.g., mvn test -DLOG_LEVEL=debug -->
-    <logger name="nl.knaw.dans.easy" level="${LOG_LEVEL:-off}"/>
+    <logger name="nl.knaw.dans.easy" level="trace"/>
     <logger name="org.scalatest" level="info"/>
 </configuration>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -130,7 +130,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     )(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
     sw.toString should fullyMatch regex
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
-        |easy-dataset:17,.*,,,,simple,FAILED: java.lang.Exception: checksum error .* easy-file:35 .*/data/original/something.txt
+        |easy-dataset:17,.*,,,,-,FAILED: java.lang.Exception: checksum error .* easy-file:35 .*/data/original/something.txt
         |""".stripMargin
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -23,6 +23,7 @@ import javax.naming.NamingEnumeration
 import javax.naming.directory.{ BasicAttributes, SearchControls, SearchResult }
 import javax.naming.ldap.InitialLdapContext
 import nl.knaw.dans.easy.fedoratobag.OutputFormat.SIP
+import nl.knaw.dans.easy.fedoratobag.TransformationType.ORIGINAL_VERSIONED
 import nl.knaw.dans.easy.fedoratobag.filter.{ BagIndex, InvalidTransformationException, SimpleDatasetFilter }
 import nl.knaw.dans.easy.fedoratobag.fixture._
 import org.scalamock.scalatest.MockFactory
@@ -96,12 +97,12 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     app.createExport(
       Iterator("easy-dataset:17"),
       (testDir / "output").createDirectories,
-      Options(SimpleDatasetFilter(), originalVersioning = true),
+      new Options(SimpleDatasetFilter(), ORIGINAL_VERSIONED),
       SIP
     )(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
     sw.toString should fullyMatch regex
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
-        |easy-dataset:17,.*,10.17026/test-Iiib-z9p-4ywa,user001,simple,OK
+        |easy-dataset:17,.*,10.17026/test-Iiib-z9p-4ywa,user001,original-versioned,OK
         |""".stripMargin
   }
 
@@ -379,7 +380,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    app.createFirstBag("easy-dataset:13", bagDir, Options(app.filter, originalVersioning = true))
+    app.createFirstBag("easy-dataset:13", bagDir, Options(app.filter, transformationType = ORIGINAL_VERSIONED))
       .map(_.nextFileInfos.map(_.path.toString).sortBy(identity)) shouldBe
       Success(Vector("original/b.pdf", "original/c.pdf", "x/a.txt", "x/e.png"))
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -63,8 +63,8 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     // make almost private methods available for tests
 
-    override def createFirstBag(datasetId: DatasetId, bagDir: File, options: Options): Try[DatasetInfo] =
-      super.createFirstBag(datasetId, bagDir, options)
+    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, firstVersionInfo: Option[VersionInfo] = None): Try[DatasetInfo] =
+      super.createBag(datasetId, bagDir, options)
   }
 
   "createExport" should "produce two bags" in {
@@ -164,7 +164,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
-    app.createFirstBag("easy-dataset:17", bagDir, Options(app.filter, strict = false)) shouldBe
+    app.createBag("easy-dataset:17", bagDir, Options(app.filter, strict = false)) shouldBe
       Failure(NoPayloadFilesException())
 
     // post conditions
@@ -194,7 +194,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
-    app.createFirstBag("easy-dataset:17", bagDir, Options(app.filter)) should matchPattern {
+    app.createBag("easy-dataset:17", bagDir, Options(app.filter)) should matchPattern {
       case Failure(_: InvalidTransformationException) =>
     }
     (testDir / "bags") shouldNot exist
@@ -221,8 +221,8 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
-    app.createFirstBag("easy-dataset:13", bagDir, Options(app.filter)) shouldBe
-      Success(DatasetInfo(None, "10.17026/mocked-Iiib-z9p-4ywa","urn:nbn:nl:ui:13-blablabla", "user001", Seq.empty))
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter)) shouldBe
+      Success(DatasetInfo(None, "10.17026/mocked-Iiib-z9p-4ywa", "urn:nbn:nl:ui:13-blablabla", "user001", Seq.empty))
 
     // post conditions
 
@@ -264,7 +264,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    app.createFirstBag("easy-dataset:13", bagDir, Options(app.filter)) should matchPattern {
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter)) should matchPattern {
       case Failure(e) if e.getMessage == "easy-file:35 <visibleTo> not found" =>
     }
   }
@@ -293,7 +293,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    val triedRecord = app.createFirstBag("easy-dataset:13", bagDir, Options(app.filter))
+    val triedRecord = app.createBag("easy-dataset:13", bagDir, Options(app.filter))
     triedRecord shouldBe a[Success[_]]
     (bagDir / "data").listRecursively.toList.map(_.name) should
       contain theSameElementsAs List("original", "c.txt", "b.txt", "a.txt")
@@ -322,7 +322,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    app.createFirstBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe a[Success[_]]
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe a[Success[_]]
     (bagDir / "data").listRecursively.toList.map(_.name) should
       contain theSameElementsAs List("original", "c.png")
   }
@@ -350,7 +350,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    app.createFirstBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe a[Success[_]]
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe a[Success[_]]
     (bagDir / "data").listRecursively.toList.map(_.name) should
       contain theSameElementsAs List("original", "c.pdf")
   }
@@ -380,7 +380,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    app.createFirstBag("easy-dataset:13", bagDir, Options(app.filter, transformationType = ORIGINAL_VERSIONED))
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter, transformationType = ORIGINAL_VERSIONED))
       .map(_.nextFileInfos.map(_.path.toString).sortBy(identity)) shouldBe
       Success(Vector("original/b.pdf", "original/c.pdf", "x/a.txt", "x/e.png"))
 
@@ -406,7 +406,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    app.createFirstBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe
       Failure(NoPayloadFilesException())
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -209,7 +209,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
   it should "report strict simple violation" in {
     val app = new AppWithMockedServices() {
       (fedoraProvider.getSubordinates(_: String)) expects "easy-dataset:17" once() returning
-        Success(Seq("easy-jumpoff:1"))
+        Success(Seq("dans-jumpoff:1"))
       Map(
         "easy-discipline:77" -> audienceFoXML("easy-discipline:77", "D13200"),
         "easy-dataset:17" -> XML.loadFile((sampleFoXML / "DepositApi.xml").toJava),

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -35,16 +35,10 @@ import scala.xml.XML
 class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupport with MockFactory with FileSystemSupport with AudienceSupport {
   implicit val logFile: File = testDir / "log.txt"
 
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    if (testDir.exists) testDir.delete()
-    testDir.createDirectories()
-  }
-
-  private class MockedLdapContext extends InitialLdapContext(new java.util.Hashtable[String, String](), null)
-
   private class AppWithMockedServices(configuration: Configuration = new Configuration("test-version", null, null, null, testDir / "staging", AbrMappings(File("src/main/assembly/dist/cfg/EMD_acdm.xsl"))),
                                      ) extends EasyFedoraToBagApp(configuration) {
+    private class MockedLdapContext extends InitialLdapContext(new java.util.Hashtable[String, String](), null)
+
     override lazy val fedoraProvider: FedoraProvider = mock[FedoraProvider]
     override lazy val ldapContext: InitialLdapContext = mock[MockedLdapContext]
     override lazy val bagIndex: BagIndex = mockBagIndexRespondsWith(body = "<result/>", code = 200)
@@ -61,8 +55,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
       (ldapContext.search(_: String, _: String, _: SearchControls)) expects(*, *, *) once() returning result
     }
 
-    // make almost private methods available for tests
-
+    // make almost private method available for tests
     override def createBag(datasetId: DatasetId, bagDir: File, options: Options, firstVersionInfo: Option[VersionInfo] = None): Try[DatasetInfo] =
       super.createBag(datasetId, bagDir, options)
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
@@ -46,7 +46,7 @@ class CreateExportSpec extends TestSupportFixture with FileFoXmlSupport with Bag
     val filter: SimpleDatasetFilter = SimpleDatasetFilter(bagIndex)
 
     /** mocks the method called by the method under test */
-    override def createFirstBag(datasetId: DatasetId, outputDir: File, options: Options): Try[DatasetInfo] = {
+    override def createBag(datasetId: DatasetId, outputDir: File, options: Options, firstVersionInfo: Option[VersionInfo] = None): Try[DatasetInfo] = {
       outputDir.parent.createDirectories()
       datasetId match {
         case _ if datasetId.startsWith("fatal") =>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
@@ -17,112 +17,105 @@ package nl.knaw.dans.easy.fedoratobag
 
 import java.io.StringWriter
 
-import better.files.File
 import com.yourmediashelf.fedora.client.FedoraClientException
-import javax.naming.ldap.InitialLdapContext
 import nl.knaw.dans.easy.fedoratobag.OutputFormat.{ AIP, SIP }
-import nl.knaw.dans.easy.fedoratobag.filter.{ BagIndex, InvalidTransformationException, SimpleDatasetFilter }
+import nl.knaw.dans.easy.fedoratobag.filter.{ InvalidTransformationException, SimpleDatasetFilter }
 import nl.knaw.dans.easy.fedoratobag.fixture._
 import org.scalamock.scalatest.MockFactory
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Failure, Success }
 
-class CreateExportSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupport with MockFactory with FileSystemSupport with AudienceSupport {
-  implicit val logFile: File = testDir / "log.txt"
+class CreateExportSpec extends TestSupportFixture with DelegatingApp with FileFoXmlSupport with BagIndexSupport with MockFactory with FileSystemSupport with AudienceSupport {
   private val stagingDir = testDir / "staging"
 
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    if (testDir.exists) testDir.delete()
-    testDir.createDirectories()
-  }
-
-  private class MockedLdapContext extends InitialLdapContext(new java.util.Hashtable[String, String](), null)
-
-  private class OverriddenApp() extends EasyFedoraToBagApp(Configuration(null, null, null, null, stagingDir, null)) {
-    override lazy val fedoraProvider: FedoraProvider = null
-    override lazy val ldapContext: InitialLdapContext = null
-    override lazy val bagIndex: BagIndex = null
-    val filter: SimpleDatasetFilter = SimpleDatasetFilter(bagIndex)
-
-    /** mocks the method called by the method under test */
-    override def createBag(datasetId: DatasetId, outputDir: File, options: Options, firstVersionInfo: Option[VersionInfo] = None): Try[DatasetInfo] = {
-      outputDir.parent.createDirectories()
-      datasetId match {
-        case _ if datasetId.startsWith("fatal") =>
-          Failure(new FedoraClientException(300, "mocked exception"))
-        case _ if datasetId.startsWith("notSimple") =>
-          outputDir.createFile().writeText(datasetId)
-          Failure(InvalidTransformationException("mocked"))
-        case _ if !datasetId.startsWith("success") =>
-          outputDir.createFile().writeText(datasetId)
-          Failure(new Exception(datasetId))
-        case _ =>
-          outputDir.createFile().writeText(datasetId)
-          Success(DatasetInfo(None, doi = "testDOI", urn = "testURN", depositor = "testUser", Seq.empty))
-      }
-    }
-  }
-
   "createSips" should "report success" in {
-    val ids = Iterator("success:1", "notSimple:1", "whoops:1", "success:1")
     val outputDir = (testDir / "output").createDirectories()
-    val app = new OverriddenApp()
+    stagingDir.createDirectories()
     val sw = new StringWriter()
+
+    val createBagExpects = Seq(
+      "easy-dataset:1" -> Success(DatasetInfo(None, "mocked-doi1", "", "user001")),
+      "easy-dataset:2" -> Failure(InvalidTransformationException("mocked")),
+      "easy-dataset:3" -> Failure(new Exception("easy-dataset:3")),
+      "easy-dataset:4" -> Success(DatasetInfo(None, "mocked-doi4", "", "user001")),
+    )
 
     // end of mocking
 
-    app.createExport(ids, outputDir, Options(SimpleDatasetFilter()), SIP)(CsvRecord.csvFormat.print(sw)) shouldBe
+    delegatingApp(stagingDir, createBagExpects).createExport(
+      Iterator("easy-dataset:1", "easy-dataset:2", "easy-dataset:3", "easy-dataset:4"),
+      outputDir, Options(SimpleDatasetFilter()), SIP
+    )(CsvRecord.csvFormat.print(sw)) shouldBe
       Success("no fedora/IO errors")
 
-    // two directories with one entry each
+    // post conditions
+
     stagingDir.list.toList should have length 2
-    stagingDir.listRecursively.toList should have length 4
-
-    // two directories with two entries each
     outputDir.list.toList should have length 2
-    outputDir.listRecursively.toList should have length 4
 
-    val csvContent = sw.toString // rest of the content tested with createAips
+    val csvContent = sw.toString
     outputDir.list.toSeq.map(_.name).foreach(packageId =>
       csvContent should include(packageId)
     )
+    csvContent should (fullyMatch regex
+      """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
+        |easy-dataset:1,.*,,mocked-doi1,user001,simple,OK
+        |easy-dataset:2,.*,,,,simple,FAILED: nl.knaw.dans.easy.fedoratobag.filter.InvalidTransformationException: mocked
+        |easy-dataset:3,.*,,,,simple,FAILED: java.lang.Exception: easy-dataset:3
+        |easy-dataset:4,.*,.*,mocked-doi4,user001,simple,OK
+        |""".stripMargin
+      )
   }
 
   "createAips" should "report success" in {
-    val ids = Iterator("success:1", "success:2")
     val outputDir = (testDir / "output").createDirectories()
     val sw = new StringWriter()
-    val app = new OverriddenApp()
+    val createBagExpects = Seq(
+      "easy-dataset:1" -> Success(DatasetInfo(None, "mocked-doi1", "", "testUser")),
+      "easy-dataset:2" -> Success(DatasetInfo(None, "mocked-doi2", "", "testUser")),
+    )
 
     // end of mocking
 
-    app.createExport(ids, outputDir, Options(app.filter), AIP)(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
+    val app = delegatingApp(stagingDir, createBagExpects)
+    app.createExport(
+      Iterator("easy-dataset:1", "easy-dataset:2"),
+      outputDir, Options(SimpleDatasetFilter(app.bagIndex)), AIP
+    )(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
 
     // post conditions
 
     val csvContent = sw.toString
     csvContent should (fullyMatch regex
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
-        |success:1,.*,testDOI,testUser,simple,OK
-        |success:2,.*,testDOI,testUser,simple,OK
+        |easy-dataset:1,.*,mocked-doi1,testUser,simple,OK
+        |easy-dataset:2,.*,mocked-doi2,testUser,simple,OK
         |""".stripMargin
       )
-    outputDir.listRecursively.toSeq should have length 2
+    outputDir.list.toSeq should have length 2
     outputDir.list.toSeq.map(_.name).foreach(packageId =>
       csvContent should include(packageId)
     )
   }
 
   it should "report failure" in {
-    val ids = Iterator("success:1", "failure:2", "notSimple:3", "success:4", "fatal:5", "success:6")
     val outputDir = (testDir / "output").createDirectories()
     val sw = new StringWriter()
-    val app = new OverriddenApp()
+    val createBagExpects = Seq(
+      "easy-dataset:1" -> Success(DatasetInfo(None, "mocked-doi1", "", "testUser")),
+      "easy-dataset:2" -> Failure(new Exception("easy-dataset:2")),
+      "easy-dataset:3" -> Failure(InvalidTransformationException("mocked")),
+      "easy-dataset:4" -> Success(DatasetInfo(None, "mocked-doi4", "", "testUser")),
+      "easy-dataset:5" -> Failure(new FedoraClientException(300, "mocked exception")),
+    )
 
     // end of mocking
 
-    app.createExport(ids, outputDir, Options(app.filter), AIP)(CsvRecord.csvFormat.print(sw)) should matchPattern {
+    val app = delegatingApp(stagingDir, createBagExpects)
+    app.createExport(
+      Iterator("easy-dataset:1", "easy-dataset:2", "easy-dataset:3", "easy-dataset:4", "easy-dataset:5", "easy-dataset:6"),
+      outputDir, Options(SimpleDatasetFilter(app.bagIndex)), AIP
+    )(CsvRecord.csvFormat.print(sw)) should matchPattern {
       case Failure(t) if t.getMessage == "mocked exception" =>
     }
 
@@ -131,19 +124,19 @@ class CreateExportSpec extends TestSupportFixture with FileFoXmlSupport with Bag
     val csvContent = sw.toString
     csvContent should (fullyMatch regex
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
-        |success:1,.*,testDOI,testUser,simple,OK
-        |failure:2,.*,,,simple,FAILED: java.lang.Exception: failure:2
-        |notSimple:3,.*,,,simple,FAILED: .*InvalidTransformationException: mocked
-        |success:4,.*,testDOI,testUser,simple,OK
+        |easy-dataset:1,.*,mocked-doi1,testUser,simple,OK
+        |easy-dataset:2,.*,,,simple,FAILED: java.lang.Exception: easy-dataset:2
+        |easy-dataset:3,.*,,,simple,FAILED: .*InvalidTransformationException: mocked
+        |easy-dataset:4,.*,mocked-doi4,testUser,simple,OK
         |""".stripMargin
       )
     outputDir.list.toSeq should have length 2
-    stagingDir.list.toSeq should have length 2
     outputDir.list.toSeq.map(_.name).foreach(packageId =>
-      csvContent should include(packageId)
+        csvContent should include(packageId)
     )
-    stagingDir.list.toSeq.map(_.name).foreach(packageId =>
-      csvContent should include(packageId)
-    )
+    // the fatal bag is staged but not in the csv
+    stagingDir.list.toSeq should have length 3
+    stagingDir.list.toSeq.map(_.name)
+      .count(csvContent.contains(_)) shouldBe 2
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
@@ -60,8 +60,8 @@ class CreateExportSpec extends TestSupportFixture with DelegatingApp with FileFo
     csvContent should (fullyMatch regex
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
         |easy-dataset:1,.*,,mocked-doi1,user001,simple,OK
-        |easy-dataset:2,.*,,,,simple,FAILED: nl.knaw.dans.easy.fedoratobag.filter.InvalidTransformationException: mocked
-        |easy-dataset:3,.*,,,,simple,FAILED: java.lang.Exception: easy-dataset:3
+        |easy-dataset:2,.*,,,,-,FAILED: nl.knaw.dans.easy.fedoratobag.filter.InvalidTransformationException: mocked
+        |easy-dataset:3,.*,,,,-,FAILED: java.lang.Exception: easy-dataset:3
         |easy-dataset:4,.*,.*,mocked-doi4,user001,simple,OK
         |""".stripMargin
       )
@@ -125,8 +125,8 @@ class CreateExportSpec extends TestSupportFixture with DelegatingApp with FileFo
     csvContent should (fullyMatch regex
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
         |easy-dataset:1,.*,mocked-doi1,testUser,simple,OK
-        |easy-dataset:2,.*,,,simple,FAILED: java.lang.Exception: easy-dataset:2
-        |easy-dataset:3,.*,,,simple,FAILED: .*InvalidTransformationException: mocked
+        |easy-dataset:2,.*,,,-,FAILED: java.lang.Exception: easy-dataset:2
+        |easy-dataset:3,.*,,,-,FAILED: .*InvalidTransformationException: mocked
         |easy-dataset:4,.*,mocked-doi4,testUser,simple,OK
         |""".stripMargin
       )

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
@@ -132,7 +132,7 @@ class CreateExportSpec extends TestSupportFixture with DelegatingApp with FileFo
       )
     outputDir.list.toSeq should have length 2
     outputDir.list.toSeq.map(_.name).foreach(packageId =>
-        csvContent should include(packageId)
+      csvContent should include(packageId)
     )
     // the fatal bag is staged but not in the csv
     stagingDir.list.toSeq should have length 3

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
@@ -59,10 +59,10 @@ class CreateExportSpec extends TestSupportFixture with DelegatingApp with FileFo
     )
     csvContent should (fullyMatch regex
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
-        |easy-dataset:1,.*,,mocked-doi1,user001,simple,OK
-        |easy-dataset:2,.*,,,,-,FAILED: nl.knaw.dans.easy.fedoratobag.filter.InvalidTransformationException: mocked
-        |easy-dataset:3,.*,,,,-,FAILED: java.lang.Exception: easy-dataset:3
-        |easy-dataset:4,.*,.*,mocked-doi4,user001,simple,OK
+        |easy-dataset:1,.+,,mocked-doi1,user001,simple,OK
+        |easy-dataset:2,.+,,,,-,FAILED: .*InvalidTransformationException: mocked
+        |easy-dataset:3,.+,,,,-,FAILED: java.lang.Exception: easy-dataset:3
+        |easy-dataset:4,.+,,mocked-doi4,user001,simple,OK
         |""".stripMargin
       )
   }
@@ -88,8 +88,8 @@ class CreateExportSpec extends TestSupportFixture with DelegatingApp with FileFo
     val csvContent = sw.toString
     csvContent should (fullyMatch regex
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
-        |easy-dataset:1,.*,mocked-doi1,testUser,simple,OK
-        |easy-dataset:2,.*,mocked-doi2,testUser,simple,OK
+        |easy-dataset:1,.+,,mocked-doi1,testUser,simple,OK
+        |easy-dataset:2,.+,,mocked-doi2,testUser,simple,OK
         |""".stripMargin
       )
     outputDir.list.toSeq should have length 2
@@ -124,10 +124,10 @@ class CreateExportSpec extends TestSupportFixture with DelegatingApp with FileFo
     val csvContent = sw.toString
     csvContent should (fullyMatch regex
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
-        |easy-dataset:1,.*,mocked-doi1,testUser,simple,OK
-        |easy-dataset:2,.*,,,-,FAILED: java.lang.Exception: easy-dataset:2
-        |easy-dataset:3,.*,,,-,FAILED: .*InvalidTransformationException: mocked
-        |easy-dataset:4,.*,mocked-doi4,testUser,simple,OK
+        |easy-dataset:1,.+,,mocked-doi1,testUser,simple,OK
+        |easy-dataset:2,.+,,,,-,FAILED: java.lang.Exception: easy-dataset:2
+        |easy-dataset:3,.+,,,,-,FAILED: .*InvalidTransformationException: mocked
+        |easy-dataset:4,.+,,mocked-doi4,testUser,simple,OK
         |""".stripMargin
       )
     outputDir.list.toSeq should have length 2

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateSequenceSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateSequenceSpec.scala
@@ -54,11 +54,11 @@ class CreateSequenceSpec extends TestSupportFixture with DelegatingApp with File
     csvContent should (fullyMatch regex
       // manual check (with break point): the value of uuid1 repeats during a sequence
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
-        |easy-dataset:1,.*,,mocked-doi1,user001,fedora-versioned,OK
-        |easy-dataset:2,.*,.*,mocked-doi2,user001,fedora-versioned,OK
-        |easy-dataset:3,.*,,mocked-doi3,user001,fedora-versioned,OK
-        |easy-dataset:4,.*,.*,mocked-doi4,user001,fedora-versioned,OK
-        |easy-dataset:5,.*,.*,mocked-doi5,user001,fedora-versioned,OK
+        |easy-dataset:1,.+,,mocked-doi1,user001,fedora-versioned,OK
+        |easy-dataset:2,.+,.+,mocked-doi2,user001,fedora-versioned,OK
+        |easy-dataset:3,.+,,mocked-doi3,user001,fedora-versioned,OK
+        |easy-dataset:4,.+,.+,mocked-doi4,user001,fedora-versioned,OK
+        |easy-dataset:5,.+,.+,mocked-doi5,user001,fedora-versioned,OK
         |""".stripMargin
       )
 
@@ -126,14 +126,14 @@ class CreateSequenceSpec extends TestSupportFixture with DelegatingApp with File
     csvContent should (fullyMatch regex
       // mocking allows to demonstrate the difference between a strict and non-strict run in a single test
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
-        |easy-dataset:10,.*,-,FAILED: .*InvalidTransformationException: Violates whatever
-        |easy-dataset:1,.*,not strict fedora-versioned,Violates something
-        |easy-dataset:2,.*,fedora-versioned,OK
-        |easy-dataset:3,.*,fedora-versioned,OK
-        |easy-dataset:4,.*,-,FAILED: .*FedoraClientException: mocked not found
-        |easy-dataset:5,.*,fedora-versioned,OK
-        |easy-dataset:6,.*,-,FAILED: .*IllegalArgumentException.*
-        |easy-dataset:8,.*,fedora-versioned,OK
+        |easy-dataset:10,,,,,-,FAILED: .*InvalidTransformationException: Violates whatever
+        |easy-dataset:1,.+,,mocked-doi,user001,not strict fedora-versioned,Violates something
+        |easy-dataset:2,.+,.+,mocked-doi,user001,fedora-versioned,OK
+        |easy-dataset:3,.+,,mocked-doi,user001,fedora-versioned,OK
+        |easy-dataset:4,.+,,,,-,FAILED: .*FedoraClientException: mocked not found
+        |easy-dataset:5,.+,.+,mocked-doi,user001,fedora-versioned,OK
+        |easy-dataset:6,,,,,-,FAILED: .*IllegalArgumentException.*
+        |easy-dataset:8,.+,,mocked-doi,user001,fedora-versioned,OK
         |""".stripMargin
       )
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateSequenceSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateSequenceSpec.scala
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.fedoratobag
+
+import java.io.StringWriter
+import java.net.URI
+
+import better.files.File
+import nl.knaw.dans.bag.v0.DansV0Bag
+import nl.knaw.dans.easy.fedoratobag.CsvRecord.csvFormat
+import nl.knaw.dans.easy.fedoratobag.fixture.{ FileFoXmlSupport, FileSystemSupport, TestSupportFixture }
+import org.scalamock.scalatest.MockFactory
+
+import scala.util.{ Success, Try }
+
+class CreateSequenceSpec extends TestSupportFixture with MockFactory with FileFoXmlSupport with FileSystemSupport {
+
+  /* delegate most of createBag to a mock to test the rest of the class and/or application */
+  def delegatingApp(exportBagExpects: Seq[(String, Try[DatasetInfo])]): EasyFedoraToBagApp = new EasyFedoraToBagApp(
+    new Configuration("testVersion", null, null, new URI(""), testDir / "staging", null)
+  ) {
+    // mock requires a constructor without parameters
+    class MockEasyFedoraToBagApp() extends EasyFedoraToBagApp(null)
+
+    private val delegate = mock[MockEasyFedoraToBagApp]
+    exportBagExpects.foreach { case (id, result) =>
+      (delegate.createBag(_: DatasetId, _: File, _: Options, _: Option[VersionInfo])
+        ) expects(id, *, *, *) returning result
+    }
+
+    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, firstVersionInfo: Option[VersionInfo] = None): Try[DatasetInfo] = {
+      // mimic a part of the real method, the tested caller wants to move the bag
+      DansV0Bag.empty(bagDir).map { bag =>
+        firstVersionInfo.foreach(_.addVersionOf(bag))
+        bag.save()
+      }.getOrElse(s"mock of createBag failed for $datasetId")
+      // mock the outcome of the method
+      delegate.createBag(datasetId, bagDir, options, firstVersionInfo)
+    }
+  }
+
+  private def outDir = {
+    (testDir / "output").createDirectories()
+  }
+
+  "createSequences" should " process 2 sequences" in {
+    val sw = new StringWriter()
+    val exportBagExpects = (1 to 5).map(i =>
+      s"easy-dataset:$i" -> Success(DatasetInfo(None, "mocked-doi", "mocked-urn", "user001", Seq.empty))
+    )
+    // end of mocking
+
+    val input =
+      """easy-dataset:1,easy-dataset:2
+        |easy-dataset:3,easy-dataset:4,easy-dataset:5
+        |""".stripMargin.split("\n").iterator
+    delegatingApp(exportBagExpects)
+      .createSequences(input, outDir)(csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
+
+    // post conditions
+
+    val csvContent = sw.toString
+    csvContent should (fullyMatch regex
+      // the value of uuid1 repeats during a sequence
+      """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
+        |easy-dataset:1,.*,,mocked-doi,user001,fedora-versioned,OK
+        |easy-dataset:2,.*,.*,mocked-doi,user001,fedora-versioned,OK
+        |easy-dataset:3,.*,,mocked-doi,user001,fedora-versioned,OK
+        |easy-dataset:4,.*,.*,mocked-doi,user001,fedora-versioned,OK
+        |easy-dataset:5,.*,.*,mocked-doi,user001,fedora-versioned,OK
+        |""".stripMargin
+      )
+    // TODO testDir/output/*/*/bag-info.txt should have 5 bags,
+    //  3 of them should have versionOf values pointing to the other 2
+  }
+
+  it should "not abort on a metadata rule violation" in {
+    val sw = new StringWriter()
+    val exportBagExpects = (2 to 5).map(i =>
+      s"easy-dataset:$i" -> Success(DatasetInfo(None, "mocked-doi", "", "user001", Seq.empty))
+    ) :+ ("easy-dataset:1" -> Success(DatasetInfo(Some("Violates something"), "mocked-doi", "", "user001", Seq.empty)))
+
+    // end of mocking
+
+    val input =
+      """easy-dataset:1,easy-dataset:2
+        |easy-dataset:3,easy-dataset:4,easy-dataset:5
+        |""".stripMargin.split("\n").iterator
+    delegatingApp(exportBagExpects)
+      .createSequences(input, outDir)(csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
+
+    // post conditions
+
+    val csvContent = sw.toString
+    // the value of uuid1 repeats during a sequence
+    csvContent should (fullyMatch regex
+      """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
+        |easy-dataset:1,.*,,mocked-doi,user001,not strict fedora-versioned,Violates something
+        |easy-dataset:2,.*,OK
+        |easy-dataset:3,.*,OK
+        |easy-dataset:4,.*,OK
+        |easy-dataset:5,.*,OK
+        |""".stripMargin
+      )
+    // TODO skip a sequence on a failing first bag
+    //  skip a single version on a failure
+  }
+  it should "abort the batch on a fedora/io/not-expected exception" in {
+    // TODO
+  }
+}

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateSequenceSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateSequenceSpec.scala
@@ -20,6 +20,8 @@ import java.io.{ IOException, StringWriter }
 import better.files.File
 import com.yourmediashelf.fedora.client.FedoraClientException
 import nl.knaw.dans.easy.fedoratobag.CsvRecord.csvFormat
+import nl.knaw.dans.easy.fedoratobag.TransformationType.FEDORA_VERSIONED
+import nl.knaw.dans.easy.fedoratobag.filter.FedoraVersionedFilter
 import nl.knaw.dans.easy.fedoratobag.fixture.{ DelegatingApp, FileSystemSupport, TestSupportFixture }
 
 import scala.util.{ Failure, Success }
@@ -29,6 +31,8 @@ class CreateSequenceSpec extends TestSupportFixture with DelegatingApp with File
   private def outDir = {
     (testDir / "output").createDirectories()
   }
+
+  private val options = new Options(FedoraVersionedFilter(), FEDORA_VERSIONED, strict = false)
 
   "createSequences" should " process 2 sequences" in {
     val sw = new StringWriter()
@@ -42,7 +46,7 @@ class CreateSequenceSpec extends TestSupportFixture with DelegatingApp with File
         |easy-dataset:3,easy-dataset:4,easy-dataset:5
         |""".stripMargin.split("\n").iterator
     delegatingApp(testDir / "staging", createBagExpects)
-      .createSequences(input, outDir)(csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
+      .createSequences(input, outDir, options)(csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
 
     // post conditions
 
@@ -109,7 +113,7 @@ class CreateSequenceSpec extends TestSupportFixture with DelegatingApp with File
         |easy-dataset:12
         |""".stripMargin.split("\n").iterator
     delegatingApp(testDir / "staging", createBagExpects)
-      .createSequences(input, outDir)(csvFormat.print(sw)) should matchPattern {
+      .createSequences(input, outDir, options)(csvFormat.print(sw)) should matchPattern {
       case Failure(_: IOException) =>
     }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateSequenceSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateSequenceSpec.scala
@@ -32,7 +32,7 @@ class CreateSequenceSpec extends TestSupportFixture with DelegatingApp with File
     (testDir / "output").createDirectories()
   }
 
-  private val options = new Options(FedoraVersionedFilter(), FEDORA_VERSIONED, strict = false)
+  private val options = Options(FedoraVersionedFilter(), FEDORA_VERSIONED, strict = false)
 
   "createSequences" should " process 2 sequences" in {
     val sw = new StringWriter()
@@ -125,9 +125,9 @@ class CreateSequenceSpec extends TestSupportFixture with DelegatingApp with File
         |easy-dataset:1,.*,not strict fedora-versioned,Violates something
         |easy-dataset:2,.*,fedora-versioned,OK
         |easy-dataset:3,.*,fedora-versioned,OK
-        |easy-dataset:4,.*,simple,FAILED: .*FedoraClientException: mocked not found
+        |easy-dataset:4,.*,-,FAILED: .*FedoraClientException: mocked not found
         |easy-dataset:5,.*,fedora-versioned,OK
-        |easy-dataset:6,.*,simple,FAILED: .*IllegalArgumentException.*
+        |easy-dataset:6,.*,-,FAILED: .*IllegalArgumentException.*
         |easy-dataset:8,.*,fedora-versioned,OK
         |""".stripMargin
       )

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DatasetFilterSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DatasetFilterSpec.scala
@@ -92,10 +92,10 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     val emd = parseEmdContent(Seq(emdTitle, emdDoi))
 
     simpleChecker(loggerExpectsWarnings = Seq(
-      "violated 2: has jump off easy-jumpoff:123",
+      "violated 2: has jump off dans-jumpoff:123",
       "violated 3: invalid title thematische collectie",
       "violated 4: invalid rights not found",
-    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq("easy-jumpoff:123")) shouldBe
+    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq("dans-jumpoff:123")) shouldBe
       Success(Some("Violates 2: has jump off; 3: invalid title; 4: invalid rights (not found)"))
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
@@ -18,8 +18,10 @@ package nl.knaw.dans.easy.fedoratobag.fixture
 import java.net.URI
 
 import better.files.File
+import javax.naming.ldap.InitialLdapContext
 import nl.knaw.dans.bag.v0.DansV0Bag
-import nl.knaw.dans.easy.fedoratobag.{ Configuration, DatasetId, DatasetInfo, EasyFedoraToBagApp, Options, VersionInfo }
+import nl.knaw.dans.easy.fedoratobag.filter.BagIndex
+import nl.knaw.dans.easy.fedoratobag.{ Configuration, DatasetId, DatasetInfo, EasyFedoraToBagApp, FedoraProvider, Options, VersionInfo }
 import org.scalamock.scalatest.MockFactory
 
 import scala.util.Try
@@ -31,7 +33,11 @@ trait DelegatingApp extends MockFactory {
     new Configuration("testVersion", null, null, new URI(""), staging, null)
   ) {
     // mock requires a constructor without parameters
-    class MockEasyFedoraToBagApp() extends EasyFedoraToBagApp(null)
+    class MockEasyFedoraToBagApp() extends EasyFedoraToBagApp(null){
+      override lazy val fedoraProvider: FedoraProvider = mock[FedoraProvider]
+      override lazy val ldapContext: InitialLdapContext = mock[InitialLdapContext]
+      override lazy val bagIndex: BagIndex = mock[BagIndex]
+    }
 
     private val delegate = mock[MockEasyFedoraToBagApp]
     createBagExpects.foreach { case (id, result) =>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.fedoratobag.fixture
 
 import java.net.URI

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
@@ -1,0 +1,37 @@
+package nl.knaw.dans.easy.fedoratobag.fixture
+
+import java.net.URI
+
+import better.files.File
+import nl.knaw.dans.bag.v0.DansV0Bag
+import nl.knaw.dans.easy.fedoratobag.{ Configuration, DatasetId, DatasetInfo, EasyFedoraToBagApp, Options, VersionInfo }
+import org.scalamock.scalatest.MockFactory
+
+import scala.util.Try
+
+trait DelegatingApp extends MockFactory {
+
+  /* delegate most of createBag to a mock to test the rest of the class and/or application */
+  def delegatingApp(staging: File, createBagExpects: Seq[(String, Try[DatasetInfo])]): EasyFedoraToBagApp = new EasyFedoraToBagApp(
+    new Configuration("testVersion", null, null, new URI(""), staging, null)
+  ) {
+    // mock requires a constructor without parameters
+    class MockEasyFedoraToBagApp() extends EasyFedoraToBagApp(null)
+
+    private val delegate = mock[MockEasyFedoraToBagApp]
+    createBagExpects.foreach { case (id, result) =>
+      (delegate.createBag(_: DatasetId, _: File, _: Options, _: Option[VersionInfo])
+        ) expects(id, *, *, *) returning result
+    }
+
+    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, firstVersionInfo: Option[VersionInfo] = None): Try[DatasetInfo] = {
+      // mimic a part of the real method, the tested caller wants to move the bag
+      DansV0Bag.empty(bagDir).map { bag =>
+        firstVersionInfo.foreach(_.addVersionOf(bag))
+        bag.save()
+      }.getOrElse(s"mock of createBag failed for $datasetId")
+      // mock the outcome of the method
+      delegate.createBag(datasetId, bagDir, options, firstVersionInfo)
+    }
+  }
+}

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersionsSpec.scala
@@ -27,10 +27,9 @@ import resource.{ DefaultManagedResource, ManagedResource }
 import scala.util.{ Failure, Success, Try }
 import scala.xml.Elem
 
-class VersionsSpec extends TestSupportFixture with MockFactory {
-  class VersionsWithMocks extends Versions {
+class FedoraVersionsSpec extends TestSupportFixture with MockFactory {
+  class FedoraVersionsWithMocks extends FedoraVersions(mock[FedoraProvider]) {
     override val resolver: Resolver = mock[Resolver]
-    override val fedoraProvider: FedoraProvider = mock[FedoraProvider]
 
     def fedoraExpects(datasetID: String, returning: Elem): CallHandler2[String, String, ManagedResource[InputStream]] = {
       (fedoraProvider.datastream(_: String, _: String)) expects(datasetID, "EMD") once() returning
@@ -41,7 +40,7 @@ class VersionsSpec extends TestSupportFixture with MockFactory {
       (resolver.getDatasetId(_: String)) expects id once() returning returning
   }
   "findChains" should "not loop forever" in {
-    val versions = new VersionsWithMocks {
+    val versions = new FedoraVersionsWithMocks {
       resolverExpects("easy-dataset:1", returning = Success("easy-dataset:1")) // for readVersionIfo
       resolverExpects("easy-dataset:1", returning = Success("easy-dataset:1")) // for follow
       fedoraExpects("easy-dataset:1",
@@ -54,7 +53,7 @@ class VersionsSpec extends TestSupportFixture with MockFactory {
       Success(Seq(Seq("easy-dataset:1")))
   }
   it should "not swallow unsafeGetOrThrow in follow" in {
-    val versions = new VersionsWithMocks {
+    val versions = new FedoraVersionsWithMocks {
       resolverExpects("easy-dataset:1", returning = Success("easy-dataset:1")) // for readVersionIfo
       resolverExpects("easy-dataset:1", returning = Failure(new Exception)) // for follow
       fedoraExpects("easy-dataset:1",
@@ -94,7 +93,7 @@ class VersionsSpec extends TestSupportFixture with MockFactory {
           <emd:relation><dct:isVersionOf>easy-dataset:3</dct:isVersionOf></emd:relation>
         </emd:easymetadata>,
     )
-    val versions = new VersionsWithMocks {
+    val versions = new FedoraVersionsWithMocks {
       Seq(
         "easy-dataset:1" -> "easy-dataset:1",
         "easy-dataset:2" -> "easy-dataset:2",


### PR DESCRIPTION
Fixes DD-210 fedora versioned - export the result of a dry run
and fixes check on jum-off pages

#### When applied it will...
* [x] fix column transformationType: it can have a prefix (`not strict `) and/or suffix (` without a second bag`)
* [x] don't abort on not found in dry run
* [x] reuse `DelegatingApp` for `CreateExportSpec`
* [x] clean up duplicated code

#### Where should the reviewer @DANS-KNAW/easy @DANS-KNAW/dataversedans  start?

`CreateSequenceSpec`

#### How should this be manually tested?

Browse through Spec classes searching for `easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment` to see possible results.

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
