### PR TITLE
EASY-2813: only one title in ddm-profile

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
@@ -71,7 +71,7 @@ object DDM extends DebugEnhancedLogging {
      </ddm:profile>
      <ddm:dcmiMetadata>
        { emd.getEmdIdentifier.getDcIdentifier.asScala.map(bi => <dct:identifier xsi:type={ idType(bi) }>{ bi.getValue.trim }</dct:identifier>) }
-       { emd.getEmdTitle.getDcTitle.asScala.drop(1).map(bs => <dct:alternative xml:lang={ lang(bs) }>{ bs.getValue.trim }</dct:alternative>) }
+       { emd.getEmdTitle.getDcTitle.asScala.drop(1).map(bs => <dc:title xml:lang={ lang(bs) }>{ bs.getValue.trim }</dc:title>) }
        { emd.getEmdTitle.getTermsAlternative.asScala.map(str => <dct:alternative>{ str }</dct:alternative>) }
        { emd.getEmdDescription.getTermsAbstract.asScala.map(bs => <ddm:description xml:lang={ lang(bs) } descriptionType='Abstract'>{ bs.getValue.trim }</ddm:description>) }
        { emd.getEmdDescription.getTermsTableOfContents.asScala.map(bs => <ddm:description xml:lang={ lang(bs) } descriptionType='TableOfContents'>{ bs.getValue.trim }</ddm:description>) }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
@@ -59,7 +59,7 @@ object DDM extends DebugEnhancedLogging {
      xsi:schemaLocation={s"$schemaNameSpace $schemaLocation"}
    >
      <ddm:profile>
-       { emd.getEmdTitle.getDcTitle.asScala.map(bs => <dc:title xml:lang={ lang(bs) }>{ bs.getValue.trim }</dc:title>) }
+       { emd.getEmdTitle.getDcTitle.asScala.headOption.toSeq.map(bs => <dc:title xml:lang={ lang(bs) }>{ bs.getValue.trim }</dc:title>) }
        { emd.getEmdDescription.getDcDescription.asScala.map(bs => <dct:description xml:lang={ lang(bs) }>{ bs.getValue.trim }</dct:description>) }
        { /* instructions for reuse not specified as such in EMD */ }
        { emd.getEmdCreator.getDcCreator.asScala.map(bs => <dc:creator>{ bs.getValue.trim }</dc:creator>) }
@@ -71,6 +71,7 @@ object DDM extends DebugEnhancedLogging {
      </ddm:profile>
      <ddm:dcmiMetadata>
        { emd.getEmdIdentifier.getDcIdentifier.asScala.map(bi => <dct:identifier xsi:type={ idType(bi) }>{ bi.getValue.trim }</dct:identifier>) }
+       { emd.getEmdTitle.getDcTitle.asScala.drop(1).map(bs => <dct:alternative xml:lang={ lang(bs) }>{ bs.getValue.trim }</dct:alternative>) }
        { emd.getEmdTitle.getTermsAlternative.asScala.map(str => <dct:alternative>{ str }</dct:alternative>) }
        { emd.getEmdDescription.getTermsAbstract.asScala.map(bs => <ddm:description xml:lang={ lang(bs) } descriptionType='Abstract'>{ bs.getValue.trim }</ddm:description>) }
        { emd.getEmdDescription.getTermsTableOfContents.asScala.map(bs => <ddm:description xml:lang={ lang(bs) } descriptionType='TableOfContents'>{ bs.getValue.trim }</ddm:description>) }
@@ -93,7 +94,7 @@ object DDM extends DebugEnhancedLogging {
        { emd.getEmdCoverage.getEasSpatial.asScala.map(toXml) }
        <dct:license xsi:type="dct:URI">{ toLicenseUrl(emd.getEmdRights) }</dct:license>
        { emd.getEmdLanguage.getDcLanguage.asScala.map(bs => <dct:language xsi:type={langType(bs)}>{ langValue(bs) }</dct:language>) }
-       { if (dateCreated.size > 1) dateCreated.toSeq.tail.map(date => <dct:created>{ date }</dct:created>) }
+       { dateCreated.toSeq.drop(1).map(date => <dct:created>{ date }</dct:created>) }
      </ddm:dcmiMetadata>
    </ddm:DDM>
  }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FedoraProvider.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FedoraProvider.scala
@@ -34,7 +34,7 @@ class FedoraProvider(fedoraClient: FedoraClient) {
          |PREFIX dans: <http://dans.knaw.nl/ontologies/relations#>
          |SELECT ?s WHERE {?s dans:isSubordinateTo <info:fedora/$datasetId> . }
          |""".stripMargin)
-      .map(_.tail.map(_.split("/").last))
+      .map(_.drop(1).map(_.split("/").last))
   }
 
   private def search(query: String): Try[Seq[String]] = {

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -148,6 +148,39 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
     triedDDM.flatMap(validate) shouldBe Success(())
   }
 
+
+  "titles" should "have an overflow in alternative" in {
+    val emd = parseEmdContent(Seq(
+      <emd:title>
+          <dc:title>ABC</dc:title>
+          <dc:title>DEF</dc:title>
+          <dc:title>GHI</dc:title>
+      </emd:title>,
+      emdCreator, emdDescription, emdDates, emdRights,
+    ))
+    val triedDDM = DDM(emd, Seq("D35400"), abrMapping)
+    triedDDM.map(normalized) shouldBe Success(normalized(
+      <ddm:DDM xsi:schemaLocation={ schemaLocation }>
+        <ddm:profile>
+          <dc:title>ABC</dc:title>
+          <dct:description>YYY</dct:description>
+          { ddmCreator }
+          <ddm:created>2017-09-30</ddm:created>
+          <ddm:available>2017-09-30</ddm:available>
+          <ddm:audience>D35400</ddm:audience>
+          <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
+        </ddm:profile>
+        <ddm:dcmiMetadata>
+          <dct:alternative>DEF</dct:alternative>
+          <dct:alternative>GHI</dct:alternative>
+          <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
+        </ddm:dcmiMetadata>
+       </ddm:DDM>
+     ))
+    assume(schemaIsAvailable)
+    triedDDM.flatMap(validate) shouldBe Success(())
+  }
+
   "relations" should "all appear except STREAMING_SURROGATE_RELATION" in {
     val emd = parseEmdContent(Seq(
       emdTitle, emdCreator, emdDescription, emdDates,

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -149,7 +149,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
   }
 
 
-  "titles" should "have an overflow in alternative" in {
+  "titles" should "have an overflow in dcmiMetadata titles" in {
     val emd = parseEmdContent(Seq(
       <emd:title>
           <dc:title>ABC</dc:title>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -171,8 +171,8 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
           <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
         </ddm:profile>
         <ddm:dcmiMetadata>
-          <dct:alternative>DEF</dct:alternative>
-          <dct:alternative>GHI</dct:alternative>
+          <dc:title>DEF</dc:title>
+          <dc:title>GHI</dc:title>
           <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
         </ddm:dcmiMetadata>
        </ddm:DDM>


### PR DESCRIPTION
Fixes EASY-2813: only one title in ddm-profile

#### When applied it will...
* further titles become an alternative title
* drop(1) is a safe alternative for tail
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
