### PR TITLE
DD-208, EASY-2808: original versioned without original, handling duplicated files

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -43,7 +43,7 @@ import java.util.UUID
 import javax.naming.ldap.InitialLdapContext
 import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success, Try }
-import scala.xml.{ Comment, Elem, Node }
+import scala.xml.{ Elem, Node }
 
 class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogging {
   lazy val fedoraProvider: FedoraProvider = new FedoraProvider(new FedoraClient(configuration.fedoraCredentials))
@@ -165,9 +165,10 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ <- metadataOfBag1.list.toList
         .filter(_.name.toLowerCase.contains("license"))
         .traverse(file => copy(file.name))
-      fileItems <- datasetInfo.nextFileInfos.toList.traverse(addPayloadFileTo(bag2, isOriginalVersioned = true))
+      fileItems <- datasetInfo.nextFileInfos.toList
+        .traverse(addPayloadFileTo(bag2, isOriginalVersioned = true))
       _ <- checkNotImplementedFileMetadata(fileItems, logger)
-      _ <- createFilesXml(datasetInfo.nextFileInfos, fileItems, bag2)
+      _ <- addXmlMetadataTo(bag2, "files.xml")(filesXml(fileItems))
       _ <- bag2.save
     } yield ()
   }
@@ -229,7 +230,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ = logger.debug(s"nextFileInfos = ${ nextFileInfos.map(_.path) }")
       firstBagFileItems <- firstFileInfos.traverse(addPayloadFileTo(bag, isOriginalVersioned))
       _ <- checkNotImplementedFileMetadata(firstBagFileItems, logger)
-      _ <- createFilesXml(firstFileInfos, firstBagFileItems, bag)
+      _ <- addXmlMetadataTo(bag, "files.xml")(filesXml(firstBagFileItems))
       _ <- bag.save
       doi = emd.getEmdIdentifier.getDansManagedDoi
       urn = getUrn(datasetId, emd)
@@ -332,44 +333,17 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
     val file = bag.baseDir / "data" / target.toString
     val streamId = "EASY_FILE"
 
-    // lazy so the else branch can add the file to the bag first
-    lazy val maybeBagChecksum = fileInfo.maybeDigestType.flatMap(getChecksum(file, bag))
-    val maybeFedoraChecksum = fileInfo.maybeDigestValue
-
-    if (file.exists) verifyNameClash(file, maybeFedoraChecksum, maybeBagChecksum).flatMap { _ =>
-      FileItem(fileInfo, isOriginalVersioned).map(n => Comment(n.toOneLiner))
-    }
+    if (file.exists)
+      Failure(InvalidTransformationException(s"${ fileInfo.path } is not unique (isOriginalVersioned=$isOriginalVersioned)"))
     else for {
       fileItem <- FileItem(fileInfo, isOriginalVersioned)
       _ <- fedoraProvider
         .disseminateDatastream(fileInfo.fedoraFileId, streamId)
         .map(bag.addPayloadFile(_, target))
         .tried.flatten
-      _ <- verifyChecksums(file, maybeFedoraChecksum, maybeBagChecksum)
+      maybeBagChecksum = fileInfo.maybeDigestType.flatMap(getChecksum(file, bag))
+      _ <- verifyChecksums(file, fileInfo.maybeDigestValue, maybeBagChecksum)
     } yield fileItem
-  }
-
-  private def createFilesXml(fileInfos: Seq[FileInfo], fileItems: Seq[Node], bag: DansV0Bag) = {
-    val actualItems = fileItems.filterNot(_.isInstanceOf[Comment])
-    val nrOfDuplicates = fileInfos.size - actualItems.size
-    if (nrOfDuplicates != 0)
-      logger.warn(s"$nrOfDuplicates duplicate file(s), see comment(s) in files.xml of ${ bag.name }")
-    // TODO merge skipped fileInfos into fileItems?
-    //  See https://drivenbydata.atlassian.net/browse/EASY-2808
-    addXmlMetadataTo(bag, "files.xml")(filesXml(fileItems))
-  }
-
-  private def verifyNameClash(file: File, fedoraValue: Option[String], bagValue: Option[String]) = {
-    (bagValue, fedoraValue) match {
-      case (Some(b), Some(f)) if f == b =>
-        Success(())
-      case (Some(_), Some(_)) => Failure(new Exception(
-        s"Duplicate file paths with different checksums. Current $fedoraValue previous $bagValue, $file"
-      ))
-      case _ => Failure(new Exception(
-        s"Duplicate file paths, no checksum in fedora to verify for $file"
-      ))
-    }
   }
 
   private def verifyChecksums(file: File, fedoraValue: Option[String], bagValue: Option[String]) = {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -328,7 +328,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
     val streamId = "EASY_FILE"
     for {
       _ <- if (!file.exists) Success(())
-           else Failure(new IOException(s"${ fileInfo.path } was added to the bag before"))
+           else Failure(new Exception(s"${ fileInfo.path } was added to the bag before"))
       fileItem <- FileItem(fileInfo)
       _ <- fedoraProvider
         .disseminateDatastream(fileInfo.fedoraFileId, streamId)

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FedoraProvider.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FedoraProvider.scala
@@ -49,7 +49,7 @@ class FedoraProvider(fedoraClient: FedoraClient) {
       }
   }
 
-  def getObject(objectId: String): ManagedResource[InputStream] = {
+  private def getObject(objectId: String): ManagedResource[InputStream] = {
     managed(FedoraClient.getObjectXML(objectId).execute(fedoraClient))
       .flatMap(response => managed(response.getEntityInputStream))
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -33,6 +33,8 @@ case class FileInfo(fedoraFileId: String,
   val isOriginal: Boolean = path.startsWith("original/")
   val isAccessible: Boolean = accessibleTo.toUpperCase() != "NONE"
   val isAccessibleOriginal: Boolean = isOriginal && isAccessible
+  val withoutOriginal: Path = if (isOriginal) path.subpath(1, path.getNameCount)
+                              else path
 }
 
 object FileInfo {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -30,8 +30,9 @@ case class FileInfo(fedoraFileId: String,
                     contentDigest: Option[Node],
                     additionalMetadata: Option[Node],
                    ) {
-  val inFirstBag: Boolean = path.startsWith("original/")
-  val inSecondBag: Boolean = !inFirstBag || accessibleTo.toUpperCase() != "NONE"
+  val isOriginal: Boolean = path.startsWith("original/")
+  val isAccessible: Boolean = accessibleTo.toUpperCase() != "NONE"
+  val isAccessibleOriginal: Boolean = isOriginal && isAccessible
 }
 
 object FileInfo {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -17,10 +17,6 @@ package nl.knaw.dans.easy.fedoratobag
 
 import java.nio.file.{ Path, Paths }
 
-import better.files.File
-import nl.knaw.dans.bag.ChecksumAlgorithm
-import nl.knaw.dans.bag.v0.DansV0Bag
-
 import scala.util.Try
 import scala.xml.Node
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -34,9 +34,11 @@ case class FileInfo(fedoraFileId: String,
                     contentDigest: Option[Node],
                     additionalMetadata: Option[Node],
                    ) {
-  val isOriginal: Boolean = path.startsWith("original/")
   private val isAccessible: Boolean = accessibleTo.toUpperCase() != "NONE"
+  val isOriginal: Boolean = path.getName(0).toString.toLowerCase == "original"
   val isAccessibleOriginal: Boolean = isOriginal && isAccessible
+  val maybeDigestType: Option[String] = contentDigest.map(n => (n \\ "@TYPE").text)
+  val maybeDigestValue: Option[String] = contentDigest.map(n => (n \\ "@DIGEST").text)
 
   def bagPath(isOriginalVersioned: Boolean): Path =
     if (isOriginalVersioned && isOriginal) path.subpath(1, path.getNameCount)

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -29,7 +29,10 @@ case class FileInfo(fedoraFileId: String,
                     visibleTo: String,
                     contentDigest: Option[Node],
                     additionalMetadata: Option[Node],
-                   )
+                   ) {
+  val inFirstBag: Boolean = path.startsWith("original/")
+  val inSecondBag: Boolean = !inFirstBag || accessibleTo.toUpperCase() != "NONE"
+}
 
 object FileInfo {
   def apply(foXml: Node): Try[FileInfo] = {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -17,6 +17,10 @@ package nl.knaw.dans.easy.fedoratobag
 
 import java.nio.file.{ Path, Paths }
 
+import better.files.File
+import nl.knaw.dans.bag.ChecksumAlgorithm
+import nl.knaw.dans.bag.v0.DansV0Bag
+
 import scala.util.Try
 import scala.xml.Node
 
@@ -31,10 +35,12 @@ case class FileInfo(fedoraFileId: String,
                     additionalMetadata: Option[Node],
                    ) {
   val isOriginal: Boolean = path.startsWith("original/")
-  val isAccessible: Boolean = accessibleTo.toUpperCase() != "NONE"
+  private val isAccessible: Boolean = accessibleTo.toUpperCase() != "NONE"
   val isAccessibleOriginal: Boolean = isOriginal && isAccessible
-  val withoutOriginal: Path = if (isOriginal) path.subpath(1, path.getNameCount)
-                              else path
+
+  def bagPath(isOriginalVersioned: Boolean): Path =
+    if (isOriginalVersioned && isOriginal) path.subpath(1, path.getNameCount)
+    else path
 }
 
 object FileInfo {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
@@ -20,7 +20,7 @@ import java.util.Locale
 import com.typesafe.scalalogging.Logger
 
 import scala.util.{ Failure, Success, Try }
-import scala.xml.{ Elem, Node, NodeSeq, Text }
+import scala.xml._
 
 object FileItem {
 
@@ -52,9 +52,12 @@ object FileItem {
     else Failure(new Exception(s"${ incompleteItems.size } file(s) with not implemented additional file metadata: $tags"))
   }
 
-  def apply(fileInfo: FileInfo): Try[Node] = Try {
-      <file filepath={ "data/" + fileInfo.path }>
-        <dct:identifier>{ fileInfo.fedoraFileId }</dct:identifier>
+  def apply(fileInfo: FileInfo, isOriginalVersioned: Boolean): Try[Node] = Try {
+    val bagPath = fileInfo.bagPath(isOriginalVersioned)
+      <file filepath={ "data/" + fileInfo.bagPath(isOriginalVersioned) }>{
+          if (bagPath != fileInfo.path) Comment(fileInfo.path.toString)
+          else Text("")
+        }<dct:identifier>{ fileInfo.fedoraFileId }</dct:identifier>
         <dct:title>{ fileInfo.name }</dct:title>
         <dct:format>{ fileInfo.mimeType }</dct:format>
         <dct:extent>{ "%.1fMB".formatLocal(Locale.US, fileInfo.size / 1024 / 1024) }</dct:extent>

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
@@ -15,10 +15,9 @@
  */
 package nl.knaw.dans.easy.fedoratobag
 
-import java.util.Locale
-
 import com.typesafe.scalalogging.Logger
 
+import java.util.Locale
 import scala.util.{ Failure, Success, Try }
 import scala.xml._
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
@@ -36,7 +36,7 @@ object FileItem {
     { items }
     </files>
 
-  def checkNotImplemented(fileItems: List[Node], logger: Logger): Try[Unit] = {
+  def checkNotImplementedFileMetadata(fileItems: List[Node], logger: Logger): Try[Unit] = {
     val incompleteItems = fileItems.filter(item => (item \ "notImplemented").nonEmpty)
     incompleteItems.foreach(item =>
       (item \ "notImplemented").foreach(tag =>

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
@@ -31,18 +31,4 @@ case class Options(datasetFilter: DatasetFilter,
                    transformationType: TransformationType = SIMPLE,
                    strict: Boolean = true,
                    europeana: Boolean = false,
-                  ) {
-  private def isDCMI(node: Node) = node
-    .attribute("http://easy.dans.knaw.nl/easy/easymetadata/eas/", "scheme")
-    .exists(_.text == "DCMI")
-
-  def firstFileFilter(emd: Node): FileFilterType = {
-    if (transformationType == ORIGINAL_VERSIONED) ORIGINAL_FILES
-    else if (!europeana) ALL_FILES
-         else {
-           val dcmiType = (emd \ "type" \ "type").filter(isDCMI)
-           if (dcmiType.text.toLowerCase.trim == "text") LARGEST_PDF
-           else LARGEST_IMAGE
-         }
-  }
-}
+                  )

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
@@ -15,11 +15,8 @@
  */
 package nl.knaw.dans.easy.fedoratobag
 
-import nl.knaw.dans.easy.fedoratobag.TransformationType.{ ORIGINAL_VERSIONED, SIMPLE, TransformationType }
+import nl.knaw.dans.easy.fedoratobag.TransformationType.{ SIMPLE, TransformationType }
 import nl.knaw.dans.easy.fedoratobag.filter.DatasetFilter
-import nl.knaw.dans.easy.fedoratobag.filter.FileFilterType._
-
-import scala.xml.Node
 
 /**
  *

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/FileFilterType.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/FileFilterType.scala
@@ -23,6 +23,5 @@ object FileFilterType extends Enumeration {
   val LARGEST_IMAGE: FileFilterType = Value("LARGEST_IMAGE")
   val ALL_FILES: FileFilterType = Value("ALL_FILES")
   val ORIGINAL_FILES: FileFilterType = Value("ORIGINAL_FILES")
-  val NOT_ACCESSIBLE: FileFilterType = Value("NOT_ACCESSIBLE")
   // @formatter:on
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/package.scala
@@ -1,0 +1,65 @@
+package nl.knaw.dans.easy.fedoratobag
+
+import nl.knaw.dans.easy.fedoratobag.filter.FileFilterType._
+
+import scala.util.{ Failure, Success, Try }
+import scala.xml.Node
+
+package object filter {
+  implicit class FileInfos(val fileInfos: List[FileInfo]) extends AnyVal {
+    def selectForSecondBag(isOriginalVersioned: Boolean): List[FileInfo] = {
+      if (!isOriginalVersioned) List.empty
+      else {
+        val accessibleOriginals = fileInfos.filter(_.isAccessibleOriginal)
+        if (fileInfos.size == accessibleOriginals.size) List.empty
+        else accessibleOriginals ++ fileInfos.filterNot(_.isOriginal)
+      }
+    }
+
+
+    def selectForFirstBag(emd: Node, hasSecondBag: Boolean, europeana: Boolean): Try[List[FileInfo]] = {
+
+      def largest(by: FileFilterType, orElseBy: FileFilterType): Try[List[FileInfo]] = {
+        val infosByType = fileInfos
+          .filter(_.accessibleTo == "ANONYMOUS")
+          .groupBy(fi => if (fi.mimeType.startsWith("image/")) LARGEST_IMAGE
+                         else if (fi.mimeType.startsWith("application/pdf")) LARGEST_PDF
+                              else ALL_FILES
+          )
+        val selected = infosByType.getOrElse(by, infosByType.getOrElse(orElseBy, List.empty))
+        maxSizeUnlessEmpty(selected)
+      }
+
+      def maxSizeUnlessEmpty(selected: List[FileInfo]) = {
+        if (selected.isEmpty) Failure(NoPayloadFilesException())
+        else Success(List(selected.maxBy(_.size)))
+      }
+
+      def successUnlessEmpty(fileInfos: List[FileInfo]) = {
+        if (fileInfos.isEmpty) Failure(NoPayloadFilesException())
+        else Success(fileInfos)
+      }
+
+      val fileFilterType = if (hasSecondBag) ORIGINAL_FILES
+                           else if (!europeana) ALL_FILES
+                                else if (dcmiType(emd) == "text") LARGEST_PDF
+                                     else LARGEST_IMAGE
+      fileFilterType match {
+        case LARGEST_PDF => largest(LARGEST_PDF, LARGEST_IMAGE)
+        case LARGEST_IMAGE => largest(LARGEST_IMAGE, LARGEST_PDF)
+        case ORIGINAL_FILES => successUnlessEmpty(fileInfos.filter(_.isOriginal)) // TODO is ALL_FILES if no second bag
+        case ALL_FILES => successUnlessEmpty(fileInfos)
+      }
+    }
+  }
+
+  private def dcmiType(emd: Node): String = {
+    def hasDcmiScheme(node: Node) = node
+      .attribute("http://easy.dans.knaw.nl/easy/easymetadata/eas/", "scheme")
+      .exists(_.text == "DCMI")
+
+    (emd \ "type" \ "type")
+      .filter(hasDcmiScheme)
+      .text.toLowerCase.trim
+  }
+}

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/package.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.fedoratobag
 
 import nl.knaw.dans.easy.fedoratobag.filter.FileFilterType._
@@ -15,7 +30,6 @@ package object filter {
         else accessibleOriginals ++ fileInfos.filterNot(_.isOriginal)
       }
     }
-
 
     def selectForFirstBag(emd: Node, hasSecondBag: Boolean, europeana: Boolean): Try[List[FileInfo]] = {
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
@@ -42,7 +42,7 @@ case class FedoraVersions(fedoraProvider: FedoraProvider) extends DebugEnhancedL
       _ <- ids
         .withFilter(!collectedIds.contains(_))
         .map(findVersions)
-        .filter{
+        .filter {
           case Failure(e: FedoraClientException) if e.getStatus == 404 =>
             logger.error(e.getMessage)
             false

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -165,7 +165,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     )(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
     sw.toString should fullyMatch regex
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
-        |easy-dataset:17,.+,,,,-,FAILED: java.lang.Exception: checksum error .* easy-file:35 .*/data/something.txt
+        |easy-dataset:17,.+,,,,-,FAILED: java.lang.Exception: checksum error .* easy-file:35 .*/data/original/something.txt
         |""".stripMargin
   }
 
@@ -324,7 +324,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val triedRecord = app.createBag("easy-dataset:13", bagDir, Options(app.filter))
     triedRecord shouldBe a[Success[_]]
     (bagDir / "data").listRecursively.toList.map(_.name) should
-      contain theSameElementsAs List("c.txt", "b.txt", "a.txt")
+      contain theSameElementsAs List("original","c.txt", "b.txt", "a.txt")
   }
 
   it should "export largest image as payload" in {
@@ -352,7 +352,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
     app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe a[Success[_]]
     (bagDir / "data").listRecursively.toList.map(_.name) should
-      contain theSameElementsAs List("c.png")
+      contain theSameElementsAs List("original","c.png")
   }
 
   it should "fall back to largest pdf file" in {
@@ -380,7 +380,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
     app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe a[Success[_]]
     (bagDir / "data").listRecursively.toList.map(_.name) should
-      contain theSameElementsAs List("c.pdf")
+      contain theSameElementsAs List("original", "c.pdf")
   }
 
   it should "export only original files" in {

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -192,13 +192,6 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
       ).foreach { case (id, xml) =>
         (fedoraProvider.loadFoXml(_: String)) expects id once() returning Success(xml)
       }
-      Map(
-        "easy-file:1" -> "acabadabra",
-        "easy-file:3" -> "barbapappa",
-      ).foreach { case (id, count) =>
-        (fedoraProvider.disseminateDatastream(_: String, _: String)
-          ) expects(id, "EASY_FILE") twice() returning managed("acabadabra".inputStream)
-      }
       (fedoraProvider.getSubordinates(_: String)) expects "easy-dataset:13" once() returning
         Success(Seq("easy-file:1", "easy-file:2", "easy-file:3", "easy-file:4"))
     }
@@ -215,7 +208,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     // post condition
     sw.toString.split("\n").last should fullyMatch regex
-      s"easy-dataset:13,.*,,,,-,FAILED: .*InvalidTransformationException: a/x.txt is not unique .isOriginalVersioned=true."
+      s"easy-dataset:13,.*,,,,-,FAILED: .*InvalidTransformationException: duplicates in first bag: ; duplicates in second bag: a/x.txt .isOriginalVersioned==true."
   }
 
   "createBag" should "report not strict simple violation" in {

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -165,7 +165,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     )(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
     sw.toString should fullyMatch regex
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
-        |easy-dataset:17,.+,,,,-,FAILED: java.lang.Exception: checksum error .* easy-file:35 .*/data/original/something.txt
+        |easy-dataset:17,.+,,,,-,FAILED: java.lang.Exception: checksum error .* easy-file:35 .*/data/something.txt
         |""".stripMargin
   }
 
@@ -324,7 +324,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val triedRecord = app.createBag("easy-dataset:13", bagDir, Options(app.filter))
     triedRecord shouldBe a[Success[_]]
     (bagDir / "data").listRecursively.toList.map(_.name) should
-      contain theSameElementsAs List("original", "c.txt", "b.txt", "a.txt")
+      contain theSameElementsAs List("c.txt", "b.txt", "a.txt")
   }
 
   it should "export largest image as payload" in {
@@ -352,7 +352,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
     app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe a[Success[_]]
     (bagDir / "data").listRecursively.toList.map(_.name) should
-      contain theSameElementsAs List("original", "c.png")
+      contain theSameElementsAs List("c.png")
   }
 
   it should "fall back to largest pdf file" in {
@@ -380,7 +380,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
     app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe a[Success[_]]
     (bagDir / "data").listRecursively.toList.map(_.name) should
-      contain theSameElementsAs List("original", "c.pdf")
+      contain theSameElementsAs List("c.pdf")
   }
 
   it should "export only original files" in {
@@ -413,7 +413,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
       Success(Vector("original/b.pdf", "original/c.pdf", "x/a.txt", "x/e.png"))
 
     (bagDir / "data").listRecursively.toList.map(_.name) should
-      contain theSameElementsAs List("original", "c.pdf", "b.pdf", "d.pdf")
+      contain theSameElementsAs List("c.pdf", "b.pdf", "d.pdf")
   }
 
   it should "cause NoPayloadFilesException" in {

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -165,7 +165,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     )(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
     sw.toString should fullyMatch regex
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
-        |easy-dataset:17,.+,,,,-,FAILED: java.lang.Exception: checksum error .* easy-file:35 .*/data/original/something.txt
+        |easy-dataset:17,.+,,,,-,FAILED: java.lang.Exception: Different checksums in fedora Some(.*) and bag Some(.*) for .*/data/original/something.txt
         |""".stripMargin
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -324,7 +324,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val triedRecord = app.createBag("easy-dataset:13", bagDir, Options(app.filter))
     triedRecord shouldBe a[Success[_]]
     (bagDir / "data").listRecursively.toList.map(_.name) should
-      contain theSameElementsAs List("original","c.txt", "b.txt", "a.txt")
+      contain theSameElementsAs List("original", "c.txt", "b.txt", "a.txt")
   }
 
   it should "export largest image as payload" in {
@@ -352,7 +352,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
     app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe a[Success[_]]
     (bagDir / "data").listRecursively.toList.map(_.name) should
-      contain theSameElementsAs List("original","c.png")
+      contain theSameElementsAs List("original", "c.png")
   }
 
   it should "fall back to largest pdf file" in {

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -215,7 +215,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     // post condition
     sw.toString.split("\n").last should fullyMatch regex
-      s"easy-dataset:13,.*,,,,-,FAILED: .*InvalidTransformationException: a/x.txt is not unique"
+      s"easy-dataset:13,.*,,,,-,FAILED: .*InvalidTransformationException: a/x.txt is not unique .isOriginalVersioned=true."
   }
 
   "createBag" should "report not strict simple violation" in {

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
@@ -356,7 +356,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
     ).foreach(s => (mockLogger.warn(_: String)) expects s once())
     (() => mockLogger.isWarnEnabled()) expects() anyNumberOfTimes() returning true
 
-    FileItem.checkNotImplemented(List(triedFileItem.get), Logger(mockLogger)) should matchPattern {
+    FileItem.checkNotImplementedFileMetadata(List(triedFileItem.get), Logger(mockLogger)) should matchPattern {
       case Failure(e) if e.getMessage == "1 file(s) with not implemented additional file metadata: List(original_file AND archival_name)" =>
     }
   }
@@ -387,7 +387,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
     ).foreach(s => (mockLogger.warn(_: String)) expects s once())
     (() => mockLogger.isWarnEnabled()) expects() anyNumberOfTimes() returning true
 
-    FileItem.checkNotImplemented(items.toList, Logger(mockLogger)) should matchPattern {
+    FileItem.checkNotImplementedFileMetadata(items.toList, Logger(mockLogger)) should matchPattern {
       case Failure(e) if e.getMessage == "2 file(s) with not implemented additional file metadata: List(analytic_units, mapprojection, opmerkingen)" =>
     }
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
@@ -39,7 +39,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
                        <accessibleTo>RESTRICTED_REQUEST</accessibleTo>
 
     val triedFileItem = FileInfo(fileFoXml(fileMetadata))
-      .flatMap(FileItem(_))
+      .flatMap(FileItem(_, isOriginalVersioned = false))
       .map(trim)
     triedFileItem shouldBe Success(trim(
       <file filepath="data/original/something.txt">
@@ -63,7 +63,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
                        <visibleTo>NONE</visibleTo>
 
     val triedFileItem = FileInfo(fileFoXml(fileMetadata))
-      .flatMap(FileItem(_))
+      .flatMap(FileItem(_, isOriginalVersioned = false))
       .map(trim)
     triedFileItem.map(trim) shouldBe Success(trim(
       <file filepath="data/original/something.txt">
@@ -86,7 +86,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
                        <visibleTo>ANONYMOUS</visibleTo>
 
     FileInfo(fileFoXml(fileMetadata))
-      .flatMap(FileItem(_))
+      .flatMap(FileItem(_, isOriginalVersioned = false))
       .map(trim) should matchPattern {
       case Failure(e: Exception) if e.getMessage ==
         "<accessibleTo> not found" =>
@@ -128,7 +128,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
     }
 
     val triedFileItem = FileInfo(fileFoXml(fileMetadata))
-      .flatMap(FileItem(_))
+      .flatMap(FileItem(_, isOriginalVersioned = false))
       .map(trim)
     triedFileItem.map(trim) shouldBe Success(trim(
       <file filepath="data/Fotos/R0011867.jpg">
@@ -184,7 +184,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
     }
 
     val triedFileItem = FileInfo(fileFoXml(fileMetadata))
-      .flatMap(FileItem(_))
+      .flatMap(FileItem(_, isOriginalVersioned = false))
       .map(trim)
     triedFileItem.map(trim) shouldBe Success(trim(
       <file filepath="data/Fotos/R0011867.jpg">
@@ -234,7 +234,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
     // note that we have two times <dct:title>,
     // once from <name>, once from <addmd:additional-metadata><file_name>
     val triedFileItem = FileInfo(fileFoXml(fileMetadata))
-      .flatMap(FileItem(_))
+      .flatMap(FileItem(_, isOriginalVersioned = false))
       .map(trim)
     triedFileItem.map(trim) shouldBe Success(trim(
       <file filepath="data/GIS/SKKJ6_spoor.mif">
@@ -287,7 +287,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
     }
 
     val triedFileItem = FileInfo(fileFoXml(fileMetadata))
-      .flatMap(FileItem(_))
+      .flatMap(FileItem(_, isOriginalVersioned = false))
       .map(trim)
     triedFileItem.map(trim) shouldBe Success(trim(
       <file filepath="data/B">
@@ -334,7 +334,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
     }
 
     val triedFileItem = FileInfo(fileFoXml(fileMetadata))
-      .flatMap(FileItem(_))
+      .flatMap(FileItem(_, isOriginalVersioned = false))
       .map(trim)
     triedFileItem.map(trim) shouldBe Success(trim(
       <file filepath="data/B">

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
@@ -203,7 +203,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
     assume(schemaIsAvailable)
     triedFileItem.flatMap(validateItem) shouldBe Success(())
   }
-  
+
   it should "use file name as second title (first title from mandatory name)" in {
     val fileMetadata = {
       <name>SKKJ6_spoor.mix</name>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
@@ -33,7 +33,7 @@ trait DelegatingApp extends MockFactory {
     new Configuration("testVersion", null, null, new URI(""), staging, null)
   ) {
     // mock requires a constructor without parameters
-    class MockEasyFedoraToBagApp() extends EasyFedoraToBagApp(null){
+    class MockEasyFedoraToBagApp() extends EasyFedoraToBagApp(null) {
       override lazy val fedoraProvider: FedoraProvider = mock[FedoraProvider]
       override lazy val ldapContext: InitialLdapContext = mock[InitialLdapContext]
       override lazy val bagIndex: BagIndex = mock[BagIndex]


### PR DESCRIPTION
Fixes
* DD-208: original versioned: without original level in file paths
* EASY-2808: report duplicated files as an error

#### When applied it will...
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/dataversedans  @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
