### PR TITLE
EASY-2810 not implemented ddm relation

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
@@ -340,7 +340,7 @@ object DDM extends DebugEnhancedLogging {
     }.getOrElse {
       if (uri.toString.startsWith("10.17026/")) s"https://doi.org/$uri"
       else if (uri.toString.isBlank) null
-           else ???
+           else uri.toString
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -247,6 +247,32 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
     assume(schemaIsAvailable)
     triedDDM.flatMap(validate) shouldBe Success(())
   }
+  it should "prefix www with https://" in {
+    val emd = parseEmdContent(Seq(
+      emdTitle, emdCreator, emdDescription, emdDates,
+        <emd:relation>
+          <eas:replaces>
+              <eas:subject-title>Vlaardingen</eas:subject-title>
+              <eas:subject-link>www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-mp3-pb2</eas:subject-link>
+          </eas:replaces>
+        </emd:relation>,
+      emdRights,
+    ))
+    val triedDDM = DDM(emd, Seq("D35400"), abrMapping)
+    triedDDM.map(normalized) shouldBe Success(normalized(
+      <ddm:DDM xsi:schemaLocation={ schemaLocation }>
+        { ddmProfile("D35400") }
+        <ddm:dcmiMetadata>
+          <ddm:replaces scheme="id-type:URN" href="https://www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-mp3-pb2">
+            Vlaardingen
+          </ddm:replaces>
+          <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
+        </ddm:dcmiMetadata>
+      </ddm:DDM>
+    ))
+    assume(schemaIsAvailable)
+    triedDDM.flatMap(validate) shouldBe Success(())
+  }
 
   "identifiers" should "produce " in {
     val emd = parseEmdContent(Seq(

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -247,7 +247,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
     assume(schemaIsAvailable)
     triedDDM.flatMap(validate) shouldBe Success(())
   }
-  it should "prefix www with https://" in {
+  it should "add protocol if missing in href" in {
     val emd = parseEmdContent(Seq(
       emdTitle, emdCreator, emdDescription, emdDates,
         <emd:relation>
@@ -263,7 +263,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>
         { ddmProfile("D35400") }
         <ddm:dcmiMetadata>
-          <ddm:replaces scheme="id-type:URN" href="https://www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-mp3-pb2">
+          <ddm:replaces href="www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-mp3-pb2">
             Vlaardingen
           </ddm:replaces>
           <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>


### PR DESCRIPTION
Fixes EASY-2810 not implemented ddm relation

#### When applied it will...
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
