### PR TITLE
DD-343: fedora versions not properly assembled

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/BagVersion.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/BagVersion.scala
@@ -15,24 +15,24 @@
  */
 package nl.knaw.dans.easy.fedoratobag
 
-import java.util.UUID
-
 import nl.knaw.dans.bag.v0.DansV0Bag
 
-case class VersionInfo(
-                        doi: String,
-                        urn: String,
-                        packageId: UUID,
-                      ) {
+import java.util.UUID
+
+case class BagVersion(
+                       doi: String,
+                       urn: String,
+                       packageId: UUID,
+                     ) {
   def addVersionOf(bag: DansV0Bag): DansV0Bag = {
     bag.withIsVersionOf(packageId)
-      // the following keys should match easy-fedora-to-bag
+      // the following keys should match easy-convert-bag-to-deposit BagInfo
       .addBagInfo("Base-DOI", doi)
       .addBagInfo("Base-URN", urn)
   }
 }
-object VersionInfo {
-  def apply(datasetInfo: DatasetInfo, packageID: UUID): VersionInfo = {
-    VersionInfo(datasetInfo.doi, datasetInfo.urn, packageID)
+object BagVersion {
+  def apply(datasetInfo: DatasetInfo, packageID: UUID): BagVersion = {
+    BagVersion(datasetInfo.doi, datasetInfo.urn, packageID)
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/BagVersion.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/BagVersion.scala
@@ -24,7 +24,7 @@ case class BagVersion(
                        urn: String,
                        packageId: UUID,
                      ) {
-  def addVersionOf(bag: DansV0Bag): DansV0Bag = {
+  def addTo(bag: DansV0Bag): DansV0Bag = {
     bag.withIsVersionOf(packageId)
       // the following keys should match easy-convert-bag-to-deposit BagInfo
       .addBagInfo("Base-DOI", doi)

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
@@ -74,7 +74,7 @@ object Command extends App with DebugEnhancedLogging {
     val printer = CsvRecord.printer(csvLogFile)
     if (transformationType == FEDORA_VERSIONED)
       printer.apply(app.createSequences(datasetIds, commandLine.outputDir(), options))
-    else printer.apply(app.createExport(datasetIds, commandLine.outputDir(), options, commandLine.outputFormat()))
+    else printer.apply(app.createOriginalVersionedExport(datasetIds, commandLine.outputDir(), options, commandLine.outputFormat()))
   }
 
   private def datasetIds = {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/CommandLineOptions.scala
@@ -32,7 +32,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val description: String = s"""Tool for exporting datasets from Fedora and constructing Archival/Submission Information Packages."""
   val synopsis: String =
     s"""
-       |  easy-fedora-to-bag {-d <dataset-id> | -i <dataset-ids-file>} -o <staged-AIP-dir> [-s] [-l <log-file>] [-e] -f { AIP | SIP } <transformation>
+       |  easy-fedora-to-bag {-d <dataset-id> | -i <dataset-ids-file>} -o <output-dir> [-s] [-l <log-file>] [-e] -f { AIP | SIP } <transformation>
      """.stripMargin
 
   version(s"$printedName v${ configuration.version }")
@@ -56,7 +56,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val inputFile: ScallopOption[File] = opt(name = "input-file", short = 'i',
     descr = "File containing a newline-separated list of easy-dataset-ids to be transformed. Use either this or the dataset-id argument")
   val outputDir: ScallopOption[File] = opt(name = "output-dir", short = 'o',
-    descr = "Empty directory in which to stage the created IPs. It will be created if it doesn't exist.")
+    descr = "Empty directory that will be created if it doesn't exist. Successful bags (or packages) will be moved to this directory.")
   val outputFormat: ScallopOption[OutputFormat] = opt(name = "output-format", short = 'f',
     descr = OutputFormat.values.mkString("Output format: ", ", ", ". 'SIP' is only implemented for simple, it creates the bags one directory level deeper. easy-bag-to-deposit completes these sips with deposit.properties"))
   val logFile: ScallopOption[File] = opt(name = "log-file", short = 'l',

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DatasetInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DatasetInfo.scala
@@ -19,5 +19,5 @@ case class DatasetInfo(maybeFilterViolations: Option[String],
                        doi: String,
                        urn: String,
                        depositor: Depositor,
-                       nextFileInfos: Seq[FileInfo] = Seq.empty,
+                       nextBagFileInfos: Seq[FileInfo] = Seq.empty,
                       )

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/DatasetFilter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/DatasetFilter.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.fedoratobag.filter
 
 import nl.knaw.dans.common.lang.dataset.AccessCategory.{ OPEN_ACCESS, REQUEST_PERMISSION }
 import nl.knaw.dans.easy.fedoratobag._
-import nl.knaw.dans.easy.fedoratobag.versions.VersionInfo
+import nl.knaw.dans.easy.fedoratobag.versions.EmdVersionInfo
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.pf.language.emd.EasyMetadataImpl
 
@@ -98,8 +98,8 @@ trait DatasetFilter extends DebugEnhancedLogging {
   private def hasDansId(node: Node): Boolean = {
     // see both DDM.toRelationXml methods for what might occur
     (node \@ "href", node.text) match {
-      case (href, _) if VersionInfo.isDansId(href) => true
-      case (_, text) if VersionInfo.isDansId(text) => true
+      case (href, _) if EmdVersionInfo.isDansId(href) => true
+      case (_, text) if EmdVersionInfo.isDansId(text) => true
       case _ => false
     }
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/package.scala
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.easy
 
+import nl.knaw.dans.bag.v0.DansV0Bag
 import org.joda.time.format.{ DateTimeFormatter, ISODateTimeFormat }
 import org.joda.time.{ DateTime, DateTimeZone }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/EmdVersionInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/EmdVersionInfo.scala
@@ -38,9 +38,9 @@ object EmdVersionInfo {
       .getOrElse("1900-01-01")
     new EmdVersionInfo(
       submitted = fixDateIfTooLarge(date).getOrElse(0),
-      self = (emd \ "identifier" \ "identifier").theSeq.filter(isSelf).map(_.text),
-      previous = getDansIDs((relations \ "replaces").theSeq ++ (relations \ "isVersionOf").theSeq),
-      next = getDansIDs((relations \ "replacedBy").theSeq ++ (relations \ "hasVersion").theSeq),
+      self = (emd \ "identifier" \ "identifier").filter(isSelf).map(_.text),
+      previous = getDansIDs((relations \ "replaces") ++ (relations \ "isVersionOf")),
+      next = getDansIDs((relations \ "replacedBy") ++ (relations \ "hasVersion")),
     )
   }
 
@@ -53,11 +53,11 @@ object EmdVersionInfo {
   val easNameSpace = "http://easy.dans.knaw.nl/easy/easymetadata/eas/"
 
   private def isSelf(node: Node) = {
-    val scheme = node
+    node
       .attribute(easNameSpace, "scheme")
       .map(_.text)
       .getOrElse("")
-    Seq("PID", "DMO_ID", "DOI").exists(scheme.contains)
+      .matches("(PID|DMO_ID|DOI)")
   }
 
   private def getDansIDs(relations: Seq[Node]) = {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/EmdVersionInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/EmdVersionInfo.scala
@@ -22,25 +22,25 @@ import org.joda.time.format.DateTimeFormat.forPattern
 import scala.util.Try
 import scala.xml.{ Elem, Node }
 
-case class VersionInfo(submitted: Long,
-                       self: Seq[String],
-                       previous: Seq[String],
-                       next: Seq[String],
-                      )
+case class EmdVersionInfo(submitted: Long,
+                          self: Seq[String],
+                          previous: Seq[String],
+                          next: Seq[String],
+                         )
 
-object VersionInfo {
-  def apply(emd: Elem): Try[VersionInfo] = Try {
+object EmdVersionInfo {
+  def apply(emd: Elem): Try[EmdVersionInfo] = Try {
     val relations = emd \ "relation"
     val dateContainer = emd \ "date"
     val date = (dateContainer \ "dateSubmitted").headOption
       .getOrElse(dateContainer \ "created").headOption
       .map(_.text)
       .getOrElse("1900-01-01")
-    new VersionInfo(
-      fixDateIfTooLarge(date).getOrElse(0),
-      (emd \ "identifier" \ "identifier").theSeq.filter(isSelf).map(_.text),
-      getDansIDs((relations \ "replaces").theSeq ++ (relations \ "isVersionOf").theSeq),
-      getDansIDs((relations \ "replacedBy").theSeq ++ (relations \ "hasVersion").theSeq),
+    new EmdVersionInfo(
+      submitted = fixDateIfTooLarge(date).getOrElse(0),
+      self = (emd \ "identifier" \ "identifier").theSeq.filter(isSelf).map(_.text),
+      previous = getDansIDs((relations \ "replaces").theSeq ++ (relations \ "isVersionOf").theSeq),
+      next = getDansIDs((relations \ "replacedBy").theSeq ++ (relations \ "hasVersion").theSeq),
     )
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/EmdVersionInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/EmdVersionInfo.scala
@@ -26,7 +26,9 @@ case class EmdVersionInfo(submitted: Long,
                           self: Seq[String],
                           previous: Seq[String],
                           next: Seq[String],
-                         )
+                         ) {
+  override def toString = s"EmdVersionInfo: ${new DateTime(submitted)}; self=${self.mkString("(",",",")")}; previous=${previous.mkString("(",",",")")}; next=${next.mkString("(",",",")")}"
+}
 
 object EmdVersionInfo {
   def apply(emd: Elem): Try[EmdVersionInfo] = Try {
@@ -53,11 +55,12 @@ object EmdVersionInfo {
   val easNameSpace = "http://easy.dans.knaw.nl/easy/easymetadata/eas/"
 
   private def isSelf(node: Node) = {
-    node
+    val scheme = node
       .attribute(easNameSpace, "scheme")
       .map(_.text)
       .getOrElse("")
-      .matches("(PID|DMO_ID|DOI)")
+    val bool = scheme.matches("(PID|DMO_ID|DOI)")
+    bool
   }
 
   private def getDansIDs(relations: Seq[Node]) = {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
@@ -23,6 +23,9 @@ import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import scala.collection.mutable
 import scala.util.{ Failure, Success, Try }
 import scala.xml.XML
+import cats.instances.list._
+import cats.instances.try_._
+import cats.syntax.traverse._
 
 case class FedoraVersions(fedoraProvider: FedoraProvider) extends DebugEnhancedLogging {
   val resolver: Resolver = Resolver()

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
@@ -67,6 +67,7 @@ case class FedoraVersions(fedoraProvider: FedoraProvider) extends DebugEnhancedL
         family.keySet.intersect(connections.toSet).nonEmpty
       ) // not inline: changing while searching might require a specific order
       connectedWith.foreach { oldFamily =>
+        logger.info(s"$startDatasetId family merged with $oldFamily")
         families -= oldFamily
         family ++= oldFamily
       }
@@ -122,6 +123,7 @@ case class FedoraVersions(fedoraProvider: FedoraProvider) extends DebugEnhancedL
       _ <- follow(emdVersionInfo.next, _.next)
       _ = log()
       _ = if (connections.nonEmpty) connect()
+      _ = logger.info(s"$startDatasetId new family $family")
       _ = families += family
     } yield connections
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
@@ -72,18 +72,18 @@ case class FedoraVersions(fedoraProvider: FedoraProvider) extends DebugEnhancedL
       }
     }
 
-    def readVersionInfo(anyId: String): Try[VersionInfo] = for {
+    def readVersionInfo(anyId: String): Try[EmdVersionInfo] = for {
       datasetId <- resolver.getDatasetId(anyId)
       emd <- fedoraProvider
         .datastream(datasetId, "EMD")
         .map(XML.load)
         .tried
-      versionInfo <- VersionInfo(emd)
+      versionInfo <- EmdVersionInfo(emd)
       _ = family += datasetId -> versionInfo.submitted
       _ = collectedIds ++= (versionInfo.self :+ datasetId).distinct
     } yield versionInfo
 
-    def follow(ids: Seq[String], f: VersionInfo => Seq[String]): Try[Unit] = {
+    def follow(ids: Seq[String], f: EmdVersionInfo => Seq[String]): Try[Unit] = {
       val grouped = ids.groupBy(collectedIds.contains(_))
 
       connections ++= grouped.get(true).toSeq.flatten
@@ -111,8 +111,8 @@ case class FedoraVersions(fedoraProvider: FedoraProvider) extends DebugEnhancedL
         )
       )
       if (family.values.exists(_ <= 0))
-        logger.warn(msg)
-      else logger.info(msg) // default dates: before 1970
+        logger.warn(msg + " date before 1970")
+      else logger.info(msg)
     }
 
     for {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
@@ -114,7 +114,7 @@ case class FedoraVersions(fedoraProvider: FedoraProvider) extends DebugEnhancedL
         )
       )
       if (family.values.exists(_ <= 0))
-        logger.warn(msg + " date before 1970")
+        logger.warn(msg)
       else logger.info(msg)
     }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersions.scala
@@ -116,12 +116,14 @@ case class FedoraVersions(fedoraProvider: FedoraProvider) extends DebugEnhancedL
     }
 
     for {
-      versionInfo <- readVersionInfo(startDatasetId)
-      _ <- follow(versionInfo.previous, _.previous)
-      _ <- follow(versionInfo.next, _.next)
+      emdVersionInfo <- readVersionInfo(startDatasetId)
+      _ = logger.info(s"start findVersions for $startDatasetId")
+      _ <- follow(emdVersionInfo.previous, _.previous)
+      _ <- follow(emdVersionInfo.next, _.next)
       _ = log()
       _ = if (connections.nonEmpty) connect()
       _ = families += family
+      _ = logger.info(s"completed findVersions without exceptions for $startDatasetId with ${families.size} families")
     } yield connections
   }
 }

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -12,6 +12,6 @@
     </root>
 
     <!-- Set log level during test with system property, e.g., mvn test -DLOG_LEVEL=debug -->
-    <logger name="nl.knaw.dans.easy" level="trace"/>
+    <logger name="nl.knaw.dans.easy" level="${LOG_LEVEL:-off}"/>
     <logger name="org.scalatest" level="info"/>
 </configuration>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -55,7 +55,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     }
 
     // make almost private method available for tests
-    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, firstBagVersion: Option[BagVersion] = None): Try[DatasetInfo] =
+    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, maybeFirstBagVersion: Option[BagVersion] = None): Try[DatasetInfo] =
       super.createBag(datasetId, bagDir, options)
   }
 
@@ -86,7 +86,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val sw = new StringWriter()
-    app.createExport(
+    app.createOriginalVersionedExport(
       Iterator("easy-dataset:17"),
       (testDir / "output").createDirectories,
       Options(SimpleDatasetFilter(allowOriginalAndOthers = true), ORIGINAL_VERSIONED),
@@ -132,7 +132,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val sw = new StringWriter()
-    app.createExport(
+    app.createOriginalVersionedExport(
       Iterator("easy-dataset:17"),
       (testDir / "output").createDirectories,
       Options(new SimpleDatasetFilter(), ORIGINAL_VERSIONED),
@@ -167,7 +167,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val sw = new StringWriter()
-    app.createExport(
+    app.createOriginalVersionedExport(
       Iterator("easy-dataset:17"),
       (testDir / "output").createDirectories,
       Options(SimpleDatasetFilter()),
@@ -199,7 +199,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val sw = new StringWriter()
-    app.createExport(
+    app.createOriginalVersionedExport(
       Iterator("easy-dataset:13"),
       (testDir / "output").createDirectories(),
       Options(SimpleDatasetFilter(allowOriginalAndOthers = true), ORIGINAL_VERSIONED),
@@ -478,7 +478,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
     app.createBag("easy-dataset:13", bagDir, Options(SimpleDatasetFilter(allowOriginalAndOthers = true), ORIGINAL_VERSIONED))
-      .map(_.nextFileInfos.map(_.path.toString).sortBy(identity)) shouldBe
+      .map(_.nextBagFileInfos.map(_.path.toString).sortBy(identity)) shouldBe
       Success(Vector("original/b.pdf", "original/c.pdf", "x/a.txt", "x/e.png"))
 
     (bagDir / "data").listRecursively.toList.map(_.name) should

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -55,7 +55,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     }
 
     // make almost private method available for tests
-    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, firstVersionInfo: Option[VersionInfo] = None): Try[DatasetInfo] =
+    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, firstBagVersion: Option[BagVersion] = None): Try[DatasetInfo] =
       super.createBag(datasetId, bagDir, options)
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
@@ -41,7 +41,7 @@ class CreateExportSpec extends TestSupportFixture with DelegatingApp with FileFo
 
     // end of mocking
 
-    delegatingApp(stagingDir, createBagExpects).createExport(
+    delegatingApp(stagingDir, createBagExpects).createOriginalVersionedExport(
       Iterator("easy-dataset:1", "easy-dataset:2", "easy-dataset:3", "easy-dataset:4"),
       outputDir, Options(SimpleDatasetFilter()), SIP
     )(CsvRecord.csvFormat.print(sw)) shouldBe
@@ -77,7 +77,7 @@ class CreateExportSpec extends TestSupportFixture with DelegatingApp with FileFo
     // end of mocking
 
     val app = delegatingApp(stagingDir, createBagExpects)
-    app.createExport(
+    app.createOriginalVersionedExport(
       Iterator("easy-dataset:1", "easy-dataset:2"),
       outputDir, Options(SimpleDatasetFilter(targetIndex = app.bagIndex)), AIP
     )(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
@@ -111,7 +111,7 @@ class CreateExportSpec extends TestSupportFixture with DelegatingApp with FileFo
     // end of mocking
 
     val app = delegatingApp(stagingDir, createBagExpects)
-    app.createExport(
+    app.createOriginalVersionedExport(
       Iterator("easy-dataset:1", "easy-dataset:2", "easy-dataset:3", "easy-dataset:4", "easy-dataset:5", "easy-dataset:6"),
       outputDir, Options(SimpleDatasetFilter(targetIndex = app.bagIndex)), AIP
     )(CsvRecord.csvFormat.print(sw)) should matchPattern {

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
@@ -15,15 +15,14 @@
  */
 package nl.knaw.dans.easy.fedoratobag.fixture
 
-import java.net.URI
-
 import better.files.File
-import javax.naming.ldap.InitialLdapContext
 import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.fedoratobag.filter.BagIndex
-import nl.knaw.dans.easy.fedoratobag.{ Configuration, DatasetId, DatasetInfo, EasyFedoraToBagApp, FedoraProvider, Options, VersionInfo }
+import nl.knaw.dans.easy.fedoratobag.{ BagVersion, Configuration, DatasetId, DatasetInfo, EasyFedoraToBagApp, FedoraProvider, Options }
 import org.scalamock.scalatest.MockFactory
 
+import java.net.URI
+import javax.naming.ldap.InitialLdapContext
 import scala.util.Try
 
 trait DelegatingApp extends MockFactory {
@@ -41,18 +40,18 @@ trait DelegatingApp extends MockFactory {
 
     private val delegate = mock[MockEasyFedoraToBagApp]
     createBagExpects.foreach { case (id, result) =>
-      (delegate.createBag(_: DatasetId, _: File, _: Options, _: Option[VersionInfo])
+      (delegate.createBag(_: DatasetId, _: File, _: Options, _: Option[BagVersion])
         ) expects(id, *, *, *) returning result
     }
 
-    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, firstVersionInfo: Option[VersionInfo] = None): Try[DatasetInfo] = {
+    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, firstBagVersion: Option[BagVersion] = None): Try[DatasetInfo] = {
       // mimic a part of the real method, the tested caller wants to move the bag
       DansV0Bag.empty(bagDir).map { bag =>
-        firstVersionInfo.foreach(_.addVersionOf(bag))
+        firstBagVersion.foreach(_.addVersionOf(bag))
         bag.save()
       }.getOrElse(s"mock of createBag failed for $datasetId")
       // mock the outcome of the method
-      delegate.createBag(datasetId, bagDir, options, firstVersionInfo)
+      delegate.createBag(datasetId, bagDir, options, firstBagVersion)
     }
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
@@ -44,14 +44,14 @@ trait DelegatingApp extends MockFactory {
         ) expects(id, *, *, *) returning result
     }
 
-    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, firstBagVersion: Option[BagVersion] = None): Try[DatasetInfo] = {
+    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, maybeFirstBagVersion: Option[BagVersion] = None): Try[DatasetInfo] = {
       // mimic a part of the real method, the tested caller wants to move the bag
       DansV0Bag.empty(bagDir).map { bag =>
-        firstBagVersion.foreach(_.addVersionOf(bag))
+        maybeFirstBagVersion.foreach(_.addTo(bag))
         bag.save()
       }.getOrElse(s"mock of createBag failed for $datasetId")
       // mock the outcome of the method
-      delegate.createBag(datasetId, bagDir, options, firstBagVersion)
+      delegate.createBag(datasetId, bagDir, options, maybeFirstBagVersion)
     }
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/BagVersionSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/BagVersionSpec.scala
@@ -20,7 +20,7 @@ import org.joda.time.DateTime
 
 import scala.util.Success
 
-class VersionInfoSpec extends TestSupportFixture {
+class BagVersionSpec extends TestSupportFixture {
   "apply" should "return all types of identifiers" in {
     VersionInfo(
       <emd:easymetadata xmlns:eas={ VersionInfo.easNameSpace }>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/EmdVersionSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/EmdVersionSpec.scala
@@ -15,10 +15,13 @@
  */
 package nl.knaw.dans.easy.fedoratobag.versions
 
+import better.files.File
 import nl.knaw.dans.easy.fedoratobag.fixture.TestSupportFixture
 import org.joda.time.DateTime
 
+import scala.reflect.runtime.universe.Try
 import scala.util.Success
+import scala.xml.XML
 
 class EmdVersionSpec extends TestSupportFixture {
   "apply" should "return all types of identifiers" in {

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/EmdVersionSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/EmdVersionSpec.scala
@@ -20,10 +20,10 @@ import org.joda.time.DateTime
 
 import scala.util.Success
 
-class BagVersionSpec extends TestSupportFixture {
+class EmdVersionSpec extends TestSupportFixture {
   "apply" should "return all types of identifiers" in {
-    VersionInfo(
-      <emd:easymetadata xmlns:eas={ VersionInfo.easNameSpace }>
+    EmdVersionInfo(
+      <emd:easymetadata xmlns:eas={ EmdVersionInfo.easNameSpace }>
         <emd:identifier>
           <dc:identifier eas:scheme="PID">urn:nbn:nl:ui:13-t3f-cz8</dc:identifier>
           <dc:identifier eas:scheme="DOI">10.17026/dans-zjf-522e</dc:identifier>
@@ -44,7 +44,7 @@ class BagVersionSpec extends TestSupportFixture {
         </emd:relation>
       </emd:easymetadata>
     ) should matchPattern {
-      case Success(VersionInfo(
+      case Success(EmdVersionInfo(
       _,
       Seq("urn:nbn:nl:ui:13-t3f-cz8", "10.17026/dans-zjf-522e", "easy-dataset:34340"),
       Seq("easy-dataset:123"),
@@ -53,18 +53,18 @@ class BagVersionSpec extends TestSupportFixture {
     }
   }
   it should "use a default Date" in {
-    VersionInfo(<emd:easymetadata/>)
+    EmdVersionInfo(<emd:easymetadata/>)
       .map(submitYear) shouldBe Success(1900)
   }
   it should "fall back to a default Date" in {
-    VersionInfo(
+    EmdVersionInfo(
       <emd:easymetadata>
         <emd:date><eas:dateSubmitted>blablabla</eas:dateSubmitted></emd:date>
       </emd:easymetadata>
     ).map(submitYear) shouldBe Success(1970)
   }
   it should "use dateSubmitted" in {
-    VersionInfo(
+    EmdVersionInfo(
       <emd:easymetadata>
         <emd:date><eas:dateCreated>1980</eas:dateCreated></emd:date>
         <emd:date><eas:dateSubmitted>1990</eas:dateSubmitted></emd:date>
@@ -72,7 +72,7 @@ class BagVersionSpec extends TestSupportFixture {
     ).map(submitYear) shouldBe Success(1990)
   }
   it should "fall back to date created" in {
-    VersionInfo(
+    EmdVersionInfo(
       <emd:easymetadata>
         <emd:date><eas:date>1980</eas:date></emd:date>
         <emd:date><dc:created>1980</dc:created></emd:date>
@@ -80,7 +80,7 @@ class BagVersionSpec extends TestSupportFixture {
     ).map(submitYear) shouldBe Success(1980)
   }
 
-  private def submitYear(l: VersionInfo) = {
+  private def submitYear(l: EmdVersionInfo) = {
     new DateTime(l.submitted).getYear
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersionsSpec.scala
@@ -123,10 +123,14 @@ class FedoraVersionsSpec extends TestSupportFixture with MockFactory {
      * INFO  easy-dataset:1 following EmdVersionInfo: 2019-12-23T00:00:00.000+01:00; self=(easy-dataset:2); previous=(easy-dataset:3); next=(10.17026/dans-zjf-522e)
      * INFO  easy-dataset:1 following EmdVersionInfo: 2018-02-12T00:00:00.000+01:00; self=(easy-dataset:4,10.17026/dans-zjf-522e); previous=(); next=()
      * INFO  easy-dataset:1 Family[4]: easy-dataset:2 -> 1577055600000, easy-dataset:1 -> 1550876400000, easy-dataset:4 -> 1518390000000, easy-dataset:3 -> 1521759600000 Connections[0]:
+     * INFO  easy-dataset:1 new family Map(easy-dataset:2 -> 1577055600000, easy-dataset:1 -> 1550876400000, easy-dataset:4 -> 1518390000000, easy-dataset:3 -> 1521759600000)
      * INFO  easy-dataset:5 EmdVersionInfo: 1900-01-01T00:00:00.000+00:19:32; self=(); previous=(); next=()
      * WARN  easy-dataset:5 Family[1]: easy-dataset:5 -> -2208989972000 Connections[0]:
+     * INFO  easy-dataset:5 new family Map(easy-dataset:5 -> -2208989972000)
      * INFO  easy-dataset:6 EmdVersionInfo: 1900-01-01T00:00:00.000+00:19:32; self=(easy-dataset:5); previous=(easy-dataset:3); next=()
      * WARN  easy-dataset:6 Family[1]: easy-dataset:6 -> -2208989972000 Connections[1]: easy-dataset:3
+     * INFO  easy-dataset:6 family merged with Map(easy-dataset:2 -> 1577055600000, easy-dataset:1 -> 1550876400000, easy-dataset:4 -> 1518390000000, easy-dataset:3 -> 1521759600000)
+     * INFO  easy-dataset:6 new family Map(easy-dataset:2 -> 1577055600000, easy-dataset:1 -> 1550876400000, easy-dataset:4 -> 1518390000000, easy-dataset:3 -> 1521759600000, easy-dataset:6 -> -2208989972000)
      *
      * warnings in case of default dates (< 1970), see date calculation in EmdVersionInfo.apply
      * nn in "[nn] Connections" implies the number of set operations in Versions.findVersions.connect

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersionsSpec.scala
@@ -15,8 +15,6 @@
  */
 package nl.knaw.dans.easy.fedoratobag.versions
 
-import java.io.InputStream
-
 import better.files._
 import nl.knaw.dans.easy.fedoratobag.fixture.TestSupportFixture
 import nl.knaw.dans.easy.fedoratobag.{ FedoraProvider, XmlExtensions }
@@ -24,6 +22,7 @@ import org.scalamock.handlers.{ CallHandler1, CallHandler2 }
 import org.scalamock.scalatest.MockFactory
 import resource.{ DefaultManagedResource, ManagedResource }
 
+import java.io.InputStream
 import scala.util.{ Failure, Success, Try }
 import scala.xml.Elem
 
@@ -67,29 +66,29 @@ class FedoraVersionsSpec extends TestSupportFixture with MockFactory {
   it should "follow in both directions" in {
     val emds = Seq(
       "easy-dataset:1" ->
-        <emd:easymetadata xmlns:eas={ VersionInfo.easNameSpace }>
+        <emd:easymetadata xmlns:eas={ EmdVersionInfo.easNameSpace }>
           <emd:date><eas:dateSubmitted>2019-02-23</eas:dateSubmitted></emd:date>
           <emd:relation><dct:hasVersion>easy-dataset:2</dct:hasVersion></emd:relation>
           <emd:relation><dct:replaces>http://www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-2ajw-cq</dct:replaces></emd:relation>
         </emd:easymetadata>,
       "easy-dataset:2" ->
-        <emd:easymetadata xmlns:eas={ VersionInfo.easNameSpace }>
+        <emd:easymetadata xmlns:eas={ EmdVersionInfo.easNameSpace }>
           <emd:date><eas:dateSubmitted>2019-12-23</eas:dateSubmitted></emd:date>
           <emd:relation><dct:replacedBy>https://doi.org/10.17026/dans-zjf-522e</dct:replacedBy></emd:relation>
           <emd:relation><dct:isVersionOf>easy-dataset:3</dct:isVersionOf></emd:relation>
         </emd:easymetadata>,
       "easy-dataset:3" ->
-        <emd:easymetadata xmlns:eas={ VersionInfo.easNameSpace }>
+        <emd:easymetadata xmlns:eas={ EmdVersionInfo.easNameSpace }>
           <emd:date><eas:dateSubmitted>2018-03-23</eas:dateSubmitted></emd:date>
         </emd:easymetadata>,
       "easy-dataset:4" ->
-        <emd:easymetadata xmlns:eas={ VersionInfo.easNameSpace }>
+        <emd:easymetadata xmlns:eas={ EmdVersionInfo.easNameSpace }>
           <emd:date><eas:dateSubmitted>2018-02-12</eas:dateSubmitted></emd:date>
         </emd:easymetadata>,
       "easy-dataset:5" ->
         <emd:easymetadata/>,
       "easy-dataset:6" ->
-        <emd:easymetadata xmlns:eas={ VersionInfo.easNameSpace }>
+        <emd:easymetadata xmlns:eas={ EmdVersionInfo.easNameSpace }>
           <emd:relation><dct:isVersionOf>easy-dataset:3</dct:isVersionOf></emd:relation>
         </emd:easymetadata>,
     )
@@ -112,7 +111,7 @@ class FedoraVersionsSpec extends TestSupportFixture with MockFactory {
      * WARN  Family: easy-dataset:5 -> -2208989972000
      * WARN  Family: easy-dataset:6 -> -2208989972000 [1]  Connections: easy-dataset:3
      *
-     * warnings in case of default dates (< 1970), see date calculation in VersionInfo.apply
+     * warnings in case of default dates (< 1970), see date calculation in EmdVersionInfo.apply
      * nn in "[nn] Connections" implies the number of set operations in Versions.findVersions.connect
      */
     versions.findChains(Iterator("easy-dataset:1", "easy-dataset:5", "easy-dataset:6")) shouldBe

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/FedoraVersionsSpec.scala
@@ -67,28 +67,39 @@ class FedoraVersionsSpec extends TestSupportFixture with MockFactory {
     val emds = Seq(
       "easy-dataset:1" ->
         <emd:easymetadata xmlns:eas={ EmdVersionInfo.easNameSpace }>
+          <emd:identifier><dc:identifier eas:scheme="DMO_ID">easy-dataset:1</dc:identifier></emd:identifier>
           <emd:date><eas:dateSubmitted>2019-02-23</eas:dateSubmitted></emd:date>
           <emd:relation><dct:hasVersion>easy-dataset:2</dct:hasVersion></emd:relation>
           <emd:relation><dct:replaces>http://www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-2ajw-cq</dct:replaces></emd:relation>
         </emd:easymetadata>,
       "easy-dataset:2" ->
         <emd:easymetadata xmlns:eas={ EmdVersionInfo.easNameSpace }>
+          <emd:identifier><dc:identifier eas:scheme="DMO_ID">easy-dataset:2</dc:identifier></emd:identifier>
           <emd:date><eas:dateSubmitted>2019-12-23</eas:dateSubmitted></emd:date>
           <emd:relation><dct:replacedBy>https://doi.org/10.17026/dans-zjf-522e</dct:replacedBy></emd:relation>
           <emd:relation><dct:isVersionOf>easy-dataset:3</dct:isVersionOf></emd:relation>
         </emd:easymetadata>,
       "easy-dataset:3" ->
         <emd:easymetadata xmlns:eas={ EmdVersionInfo.easNameSpace }>
+          <emd:identifier>
+            <dc:identifier eas:scheme="DMO_ID">easy-dataset:3</dc:identifier>
+            <dc:identifier eas:scheme="PID" eas:identification-system="http://www.persistent-identifier.nl">urn:nbn:nl:ui:13-2ajw-cq</dc:identifier>
+          </emd:identifier>
           <emd:date><eas:dateSubmitted>2018-03-23</eas:dateSubmitted></emd:date>
         </emd:easymetadata>,
       "easy-dataset:4" ->
         <emd:easymetadata xmlns:eas={ EmdVersionInfo.easNameSpace }>
+          <emd:identifier>
+            <dc:identifier eas:scheme="DMO_ID">easy-dataset:4</dc:identifier>
+            <dc:identifier eas:scheme="DOI" eas:identification-system="http://dx.doi.org">10.17026/dans-zjf-522e</dc:identifier>          <emd:date><eas:dateSubmitted>2018-02-12</eas:dateSubmitted></emd:date>
+          </emd:identifier>
           <emd:date><eas:dateSubmitted>2018-02-12</eas:dateSubmitted></emd:date>
         </emd:easymetadata>,
       "easy-dataset:5" ->
         <emd:easymetadata/>,
       "easy-dataset:6" ->
         <emd:easymetadata xmlns:eas={ EmdVersionInfo.easNameSpace }>
+          <emd:identifier><dc:identifier eas:scheme="DMO_ID">easy-dataset:5</dc:identifier></emd:identifier>
           <emd:relation><dct:isVersionOf>easy-dataset:3</dct:isVersionOf></emd:relation>
         </emd:easymetadata>,
     )
@@ -107,9 +118,15 @@ class FedoraVersionsSpec extends TestSupportFixture with MockFactory {
 
     /* logs:
      *
-     * INFO  Family: easy-dataset:2 -> 1577055600000, easy-dataset:1 -> 1550876400000, easy-dataset:4 -> 1518390000000, easy-dataset:3 -> 1521759600000
-     * WARN  Family: easy-dataset:5 -> -2208989972000
-     * WARN  Family: easy-dataset:6 -> -2208989972000 [1]  Connections: easy-dataset:3
+     * INFO  easy-dataset:1 EmdVersionInfo: 2019-02-23T00:00:00.000+01:00; self=(easy-dataset:1); previous=(urn:nbn:nl:ui:13-2ajw-cq); next=(easy-dataset:2)
+     * INFO  easy-dataset:1 following EmdVersionInfo: 2018-03-23T00:00:00.000+01:00; self=(easy-dataset:3,urn:nbn:nl:ui:13-2ajw-cq); previous=(); next=()
+     * INFO  easy-dataset:1 following EmdVersionInfo: 2019-12-23T00:00:00.000+01:00; self=(easy-dataset:2); previous=(easy-dataset:3); next=(10.17026/dans-zjf-522e)
+     * INFO  easy-dataset:1 following EmdVersionInfo: 2018-02-12T00:00:00.000+01:00; self=(easy-dataset:4,10.17026/dans-zjf-522e); previous=(); next=()
+     * INFO  easy-dataset:1 Family[4]: easy-dataset:2 -> 1577055600000, easy-dataset:1 -> 1550876400000, easy-dataset:4 -> 1518390000000, easy-dataset:3 -> 1521759600000 Connections[0]:
+     * INFO  easy-dataset:5 EmdVersionInfo: 1900-01-01T00:00:00.000+00:19:32; self=(); previous=(); next=()
+     * WARN  easy-dataset:5 Family[1]: easy-dataset:5 -> -2208989972000 Connections[0]:
+     * INFO  easy-dataset:6 EmdVersionInfo: 1900-01-01T00:00:00.000+00:19:32; self=(easy-dataset:5); previous=(easy-dataset:3); next=()
+     * WARN  easy-dataset:6 Family[1]: easy-dataset:6 -> -2208989972000 Connections[1]: easy-dataset:3
      *
      * warnings in case of default dates (< 1970), see date calculation in EmdVersionInfo.apply
      * nn in "[nn] Connections" implies the number of set operations in Versions.findVersions.connect


### PR DESCRIPTION
Fixes DD-343: fedora versions not properly assembled

#### When applied it will...
* have some classes refactored
* additional logging following the analysis of dataset families
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
