### PR TITLE
DD-395: date precision for created/available

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
@@ -286,9 +286,9 @@ object DDM extends DebugEnhancedLogging {
     </LinearRing>
   }
 
-  private def toXml(value: IsoDate): Elem = <label xsi:type={ orNull(value.getScheme) }>{ value }</label>
+  private def toXml(value: IsoDate): Elem = <label xsi:type={ orNull(value.getScheme) }>{ value.toString.replaceAll("[+]([0-9][0-9])([0-9][0-9])","+$1:$2") }</label>
 
-  private def toXml(value: BasicDate): Elem = <label xsi:type={ orNull(value.getScheme) }>{ value }</label>
+  private def toXml(value: BasicDate): Elem = <label xsi:type={ orNull(value.getScheme) }>{ value.toString.replaceAll("[+]([0-9][0-9])([0-9][0-9])","+$1:$2") }</label>
 
   def orNull(dateScheme: DateScheme): String = Option(dateScheme).map("dct:" + _.toString).orNull
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
@@ -319,7 +319,7 @@ object DDM extends DebugEnhancedLogging {
       }
     else
       d
-  }.replaceAll("T.*","") // no more than DAY precision
+  }.replaceAll("[+]([0-9][0-9])([0-9][0-9])","+$1:$2")
 
   private def toRelationXml(key: String, rel: Relation): Elem = Try {
     {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
@@ -15,8 +15,6 @@
  */
 package nl.knaw.dans.easy.fedoratobag
 
-import java.net.URI
-
 import nl.knaw.dans.common.lang.dataset.AccessCategory._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.string._
@@ -24,11 +22,10 @@ import nl.knaw.dans.pf.language.emd.types.EmdConstants.DateScheme
 import nl.knaw.dans.pf.language.emd.types._
 import nl.knaw.dans.pf.language.emd.{ EasyMetadataImpl, EmdRights }
 
+import java.net.URI
 import scala.collection.JavaConverters._
 import scala.util.Try
 import scala.xml._
-import java.time.format.DateTimeFormatter
-import java.time.{ DateTimeException, LocalDate }
 
 object DDM extends DebugEnhancedLogging {
   val schemaNameSpace: String = "http://easy.dans.knaw.nl/schemas/md/ddm/"
@@ -40,9 +37,9 @@ object DDM extends DebugEnhancedLogging {
     //    println(new EmdMarshaller(emd).getXmlString)
 
     val dateMap: Map[String, Iterable[Elem]] = getDateMap(emd)
-    val dateCreated = dateMap("created").map(d => parseDate(d.text))
+    val dateCreated = dateMap("created").map(_.text)
     val dateAvailable = {
-      val elems = dateMap("available").map(d => parseDate(d.text))
+      val elems = dateMap("available").map(_.text)
       if (elems.isEmpty) dateCreated
       else elems
     }
@@ -98,8 +95,6 @@ object DDM extends DebugEnhancedLogging {
      </ddm:dcmiMetadata>
    </ddm:DDM>
  }
-
-
 
   private def langType(bs: BasicString): String = bs.getSchemeId match {
     case "fra" | "fra/fre" | "deu" | "deu/ger" | "nld" | "nld/dut" | "dut/nld" | "eng" => "dct:ISO639-3"
@@ -286,9 +281,9 @@ object DDM extends DebugEnhancedLogging {
     </LinearRing>
   }
 
-  private def toXml(value: IsoDate): Elem = <label xsi:type={ orNull(value.getScheme) }>{ value.toString.replaceAll("[+]([0-9][0-9])([0-9][0-9])","+$1:$2") }</label>
+  private def toXml(value: IsoDate): Elem = <label xsi:type={ orNull(value.getScheme) }>{ fixDate(value) }</label>
 
-  private def toXml(value: BasicDate): Elem = <label xsi:type={ orNull(value.getScheme) }>{ value.toString.replaceAll("[+]([0-9][0-9])([0-9][0-9])","+$1:$2") }</label>
+  private def toXml(value: BasicDate): Elem = <label xsi:type={ orNull(value.getScheme) }>{ value }</label>
 
   def orNull(dateScheme: DateScheme): String = Option(dateScheme).map("dct:" + _.toString).orNull
 
@@ -298,9 +293,7 @@ object DDM extends DebugEnhancedLogging {
 
   private def isOtherDate(kv: (String, Iterable[Elem])): Boolean = !Seq("created", "available").contains(kv._1)
 
-  private def dateLabel(key: String): String = {
-    key.toOption.map("dct:" + _).getOrElse("dct:date")
-  }
+  private def dateLabel(key: String): String = key.toOption.map("dct:" + _).getOrElse("dct:date")
 
   private def getDateMap(emd: EasyMetadataImpl): Map[DatasetId, Seq[Elem]] = {
     val basicDates = emd.getEmdDate.getAllBasicDates.asScala.map { case (key, values) => key -> values.asScala.map(toXml) }
@@ -310,16 +303,19 @@ object DDM extends DebugEnhancedLogging {
       .mapValues(_.flatMap(_._2))
   }
 
-  private def parseDate(d: String): String = {
-    if(d.length > 13)
-      try {
-        LocalDate.parse(d.substring(0,8), DateTimeFormatter.BASIC_ISO_DATE).toString
-      } catch {
-        case _: DateTimeException => d
-      }
-    else
-      d
-  }.replaceAll("[+]([0-9][0-9])([0-9][0-9])","+$1:$2")
+  private def fixDate(date: IsoDate) = {
+    val year = date.getValue.getYear
+    if (year <= 9999) date
+    else {
+      // some dates where stored as yyyymmdd-01-01
+      val dateTime = date.getValue
+        .withYear(year / 10000)
+        .withMonthOfYear(year % 10000 / 100)
+        .withDayOfMonth(year % 100)
+      date.setValue(dateTime)
+      date
+    }
+  }.toString.replaceAll("[+]([0-9][0-9])([0-9][0-9])", "+$1:$2") // fix time zone
 
   private def toRelationXml(key: String, rel: Relation): Elem = Try {
     {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
@@ -315,11 +315,11 @@ object DDM extends DebugEnhancedLogging {
       try {
         LocalDate.parse(d.substring(0,8), DateTimeFormatter.BASIC_ISO_DATE).toString
       } catch {
-        case e: DateTimeException => d
+        case _: DateTimeException => d
       }
     else
       d
-  }
+  }.replaceAll("T.*","") // no more than DAY precision
 
   private def toRelationXml(key: String, rel: Relation): Elem = Try {
     {

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -1291,7 +1291,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
               <eas:date eas:scheme="W3CDTF" eas:format="MONTH">1910-04-01T00:00:00.000+00:19:32</eas:date>
               <eas:valid eas:scheme="W3CDTF" eas:format="MILLISECOND">1904-04-01T00:00:00.000+00:19:32</eas:valid>
               <eas:issued eas:scheme="W3CDTF" eas:format="MONTH">1905-04-01T00:00:00.000+00:19:32</eas:issued>
-              <eas:modified eas:scheme="W3CDTF" eas:format="MONTH">1906-04-01T00:00:00.000+00:19:32</eas:modified>
+              <eas:modified eas:scheme="W3CDTF" eas:format="MONTH">19060401-01-01T00:00:00.000+00:19:32</eas:modified>
               <eas:dateAccepted eas:scheme="W3CDTF" eas:format="MONTH">1903-04-01T00:00:00.000+00:19:32</eas:dateAccepted>
               <eas:dateCopyrighted eas:scheme="W3CDTF" eas:format="MONTH">1907-04-01T00:00:00.000+00:19:32</eas:dateCopyrighted>
               <eas:dateSubmitted eas:scheme="W3CDTF" eas:format="MONTH">1908-04-01T00:00:00.000+00:19:32</eas:dateSubmitted>
@@ -1327,7 +1327,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
           <dct:dateAccepted>05-2013</dct:dateAccepted>
           <dct:dateAccepted xsi:type="dct:W3CDTF">1903-04</dct:dateAccepted>
           <dct:valid>06-2013</dct:valid>
-          <dct:valid xsi:type="dct:W3CDTF">1904-04-01T00:00:00.000+0019</dct:valid>
+          <dct:valid xsi:type="dct:W3CDTF">1904-04-01T00:00:00.000+00:19</dct:valid>
           <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
         </ddm:dcmiMetadata>
       </ddm:DDM>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -1186,7 +1186,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
           <dc:title>XXX</dc:title>
           <dct:description>YYY</dct:description>
           { ddmCreator }
-          <ddm:created>2018-02-23</ddm:created>
+          <ddm:created>2018-02-23T00:10:34.000+01:00</ddm:created>
           <ddm:available>2017-09-30</ddm:available>
           <ddm:audience>D35400</ddm:audience>
           <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -1238,8 +1238,8 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
     val emd = parseEmdContent(Seq(
       emdTitle, emdCreator, emdDescription,
           <emd:date>
-              <dct:created>2013-03</dct:created>
               <dct:available>2013-04</dct:available>
+              <eas:created eas:scheme="W3CDTF" eas:format="MILLISECOND">2018-11-06T00:00:00.000+01:00</eas:created>
               <eas:available eas:scheme="W3CDTF" eas:format="DAY">2017-09-30T00:00:00.000+02:00</eas:available>
               <eas:available eas:scheme="W3CDTF" eas:format="MONTH">1901-04-01T00:00:00.000+00:19:32</eas:available>
           </emd:date>,
@@ -1252,7 +1252,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
           <dc:title>XXX</dc:title>
           <dct:description>YYY</dct:description>
           { ddmCreator }
-          <ddm:created>2013-03</ddm:created>
+          <ddm:created>2018-11-06</ddm:created>
           <ddm:available>2013-04</ddm:available>
           <ddm:available>2017-09-30</ddm:available>
           <ddm:available>1901-04</ddm:available>
@@ -1289,7 +1289,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
               <dct:dateSubmitted>10-2013</dct:dateSubmitted>
               <eas:date eas:scheme="W3CDTF" eas:format="MONTH">1909-04-01T00:00:00.000+00:19:32</eas:date>
               <eas:date eas:scheme="W3CDTF" eas:format="MONTH">1910-04-01T00:00:00.000+00:19:32</eas:date>
-              <eas:valid eas:scheme="W3CDTF" eas:format="MONTH">1904-04-01T00:00:00.000+00:19:32</eas:valid>
+              <eas:valid eas:scheme="W3CDTF" eas:format="MILLISECOND">1904-04-01T00:00:00.000+00:19:32</eas:valid>
               <eas:issued eas:scheme="W3CDTF" eas:format="MONTH">1905-04-01T00:00:00.000+00:19:32</eas:issued>
               <eas:modified eas:scheme="W3CDTF" eas:format="MONTH">1906-04-01T00:00:00.000+00:19:32</eas:modified>
               <eas:dateAccepted eas:scheme="W3CDTF" eas:format="MONTH">1903-04-01T00:00:00.000+00:19:32</eas:dateAccepted>
@@ -1327,7 +1327,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
           <dct:dateAccepted>05-2013</dct:dateAccepted>
           <dct:dateAccepted xsi:type="dct:W3CDTF">1903-04</dct:dateAccepted>
           <dct:valid>06-2013</dct:valid>
-          <dct:valid xsi:type="dct:W3CDTF">1904-04</dct:valid>
+          <dct:valid xsi:type="dct:W3CDTF">1904-04-01T00:00:00.000+0019</dct:valid>
           <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
         </ddm:dcmiMetadata>
       </ddm:DDM>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -1252,7 +1252,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
           <dc:title>XXX</dc:title>
           <dct:description>YYY</dct:description>
           { ddmCreator }
-          <ddm:created>2018-11-06</ddm:created>
+          <ddm:created>2018-11-06T00:00:00.000+01:00</ddm:created>
           <ddm:available>2013-04</ddm:available>
           <ddm:available>2017-09-30</ddm:available>
           <ddm:available>1901-04</ddm:available>


### PR DESCRIPTION
Fixes DD-395: date precision for created/available

#### When applied it will...
* `<eas:date>` is corrected (time zone + too big year)
* `<dct:date>` is copied as-is
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
