### PR TITLE
DD-342: No special chars in filenames

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -42,6 +42,13 @@ case class FileInfo(fedoraFileId: String,
 }
 
 object FileInfo {
+  val nonAllowedCharacters = List(':', '*', '?', '"', '<', '>', '|', ';', '#')
+
+  def replaceNonAllowedCharacters(s: String): String = {
+    s.map(char => if (nonAllowedCharacters.contains(char)) '_'
+                  else char)
+  }
+
   def apply(foXml: Node): Try[FileInfo] = {
     FoXml.getFileMD(foXml).map { fileMetadata =>
       def get(tag: String) = (fileMetadata \\ tag)
@@ -57,8 +64,8 @@ object FileInfo {
 
       new FileInfo(
         foXml \@ "PID",
-        Paths.get(get("path")),
-        get("name"),
+        Paths.get(replaceNonAllowedCharacters(get("path"))),
+        replaceNonAllowedCharacters(get("name")),
         get("size").toLong,
         get("mimeType"),
         accessibleTo,


### PR DESCRIPTION
Fixes DD-342

#### When applied it will...
* replace `non allowed characters` (in Dataverse) in `filenames`
* does the same for `filepaths`

Non allowed characters are: ':', '*', '?', '"', '<', '>', '|', ';', '#'

**Notice**: In the Jira issue only `filename` is mentioned.  I assume that the same restriction in Dataverse applies also to `filepath`. **Correct?** 




#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
