### PR TITLE
DD-412: preserve white space in XML

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -185,7 +185,8 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       foXml <- fedoraProvider.loadFoXml(datasetId)
       depositor <- getOwner(foXml)
       emdXml <- getEmd(foXml)
-      emd <- Try(emdUnmarshaller.unmarshal(emdXml.serialize))
+      emdString = emdXml.serialize.split("\n").tail.mkString("\n").trim //drop prologue
+      emd <- Try(emdUnmarshaller.unmarshal(emdString))
       amd <- getAmd(foXml)
       audiences <- emd.getEmdAudience.getDisciplines.asScala
         .map(id => getAudience(id.getValue)).collectResults

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/package.scala
@@ -45,7 +45,7 @@ package object fedoratobag {
   implicit class XmlExtensions(val elem: Node) extends AnyVal {
 
     def serialize: String = {
-      prologue + "\n" + printer.format(Utility.trim(elem))
+      prologue + "\n" + Utility.serialize(elem, preserveWhitespace = true)
     }
 
     def toOneLiner: String = {

--- a/src/test/resources/sample-foxml/DepositApi.xml
+++ b/src/test/resources/sample-foxml/DepositApi.xml
@@ -98,7 +98,8 @@
         <foxml:datastreamVersion ID="DC1.0" LABEL="Dublin Core Record" CREATED="2020-03-17T10:24:17.079Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="964">
             <foxml:xmlContent>
                 <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
-                    <dc:title>as</dc:title>
+                    <dc:title>as
+                        with another line</dc:title>
                     <dc:creator>as</dc:creator>
                     <dc:description>as</dc:description>
                     <dc:contributor>dfj, RightsHolder</dc:contributor>
@@ -263,7 +264,8 @@
             <foxml:xmlContent>
                 <emd:easymetadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/" xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/" emd:version="0.1">
                     <emd:title>
-                        <dc:title xml:lang="nld">as</dc:title>
+                        <dc:title xml:lang="nld">as
+                        with another line</dc:title>
                     </emd:title>
                     <emd:creator>
                         <eas:creator>
@@ -324,7 +326,8 @@
             <foxml:xmlContent>
                 <ddm:DDM xmlns:abr="http://www.den.nl/standaard/166/Archeologisch-Basisregister/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/" xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/" xmlns:gml="http://www.opengis.net/gml" xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd">
                     <ddm:profile>
-                        <dc:title xml:lang="nld">as</dc:title>
+                        <dc:title xml:lang="nld">as
+                        with another line</dc:title>
                         <dcterms:description xml:lang="nld">as</dcterms:description>
                         <dcx-dai:creatorDetails>
                             <dcx-dai:organization>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -142,6 +142,10 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
         |easy-dataset:17,.+,,10.17026/test-Iiib-z9p-4ywa,user001,original-versioned without second bag,OK
         |""".stripMargin
+    val Array(_,line) = sw.toString.split("\n")
+    testDir.listRecursively.filter(_.name == "dataset.xml").toSeq.head.contentAsString should
+      include ("""<dc:title xml:lang="nld">as
+                 |                        with another line</dc:title>""".stripMargin)
   }
 
   it should "report a checksum mismatch" in {
@@ -312,9 +316,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
   it should "report invalid file metadata" in {
     val invalidFileFoXml = XML.load(
       fileFoXml().serialize
-        .split("\n")
-        .filterNot(_.contains("<visibleTo>"))
-        .mkString("\n")
+        .replace("<visibleTo>ANONYMOUS</visibleTo>", "")
         .inputStream
     )
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -966,8 +966,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
           </eas:isPartOf>
           <eas:isPartOf>
               <eas:subject-title>2005-09/11</eas:subject-title>
-              <eas:subject-link>
-              </eas:subject-link>
+              <eas:subject-link/>
           </eas:isPartOf>
           <eas:isPartOf>
               <eas:subject-title>blabla</eas:subject-title>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -949,8 +949,13 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
   }
 
   "relation" should "not throw exceptions" in {
-    val emd = parseEmdContent(Seq(
-      emdTitle, emdCreator, emdDescription, emdDates,
+    val emdXML = <emd:easymetadata xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/"
+                          xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/"
+                          xmlns:dct="http://purl.org/dc/terms/"
+                          xmlns:dc="http://purl.org/dc/elements/1.1/"
+                          emd:version="0.1">{
+            Seq(
+              emdTitle, emdCreator, emdDescription, emdDates,
       <emd:relation>
           <eas:isPartOf>
               <eas:subject-title>Second Timothy: When and Where? Text and Traditions in the Subscriptions</eas:subject-title>
@@ -980,8 +985,12 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
               <eas:subject-link>doi:10.17026/dans-something-else</eas:subject-link>
           </eas:references>
       </emd:relation>,
-      emdRights,
-    ))
+              emdRights,
+            )
+      }</emd:easymetadata>
+    val emd = emdUnMarshaller.unmarshal(new PrettyPrinter(160, 2).format(emdXML))
+    // TODO fails with parseEmdContent
+
     val triedDDM = DDM(emd, Seq("D13200"), abrMapping)
     triedDDM.map(normalized) shouldBe Success(normalized(
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/EmdSupport.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/EmdSupport.scala
@@ -26,7 +26,7 @@ import scala.util.Try
 import scala.xml.{ Elem, NodeSeq, Utility }
 
 trait EmdSupport {
-  private val emdUnmarshaller = new EmdUnmarshaller(classOf[EasyMetadataImpl])
+  val emdUnmarshaller = new EmdUnmarshaller(classOf[EasyMetadataImpl])
   val abrMapping: AbrMappings = AbrMappings(File("src/main/assembly/dist/cfg/EMD_acdm.xsl"))
 
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/EmdSupport.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/EmdSupport.scala
@@ -37,9 +37,8 @@ trait EmdSupport {
                           xmlns:dc="http://purl.org/dc/elements/1.1/"
                           emd:version="0.1"
         >{ xml }</emd:easymetadata>
-    // TODO implement like https://github.com/DANS-KNAW/easy-fedora-to-bag/blob/4a4b7689e44aa0bb9c4c45dee8123899bfcd3de5/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala#L188
-    //   but that breaks https://github.com/DANS-KNAW/easy-fedora-to-bag/blob/2a47e60e8a267c00e1863f3e6e72172d4abd2e8f/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala#L952
-    Try(emdUnmarshaller.unmarshal( printer.format(Utility.trim(emdXml))))
+    val emdString = emdXml.serialize.split("\n").tail.mkString("\n").trim //drop prologue
+    Try(emdUnmarshaller.unmarshal(emdString))
       .getOrRecover(e => fail("could not load test EMD", e))
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/EmdSupport.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/EmdSupport.scala
@@ -37,8 +37,9 @@ trait EmdSupport {
                           xmlns:dc="http://purl.org/dc/elements/1.1/"
                           emd:version="0.1"
         >{ xml }</emd:easymetadata>
-    val emdString = emdXml.serialize.split("\n").tail.mkString("\n").trim //drop prologue
-    Try(emdUnmarshaller.unmarshal(emdString))
+    // TODO implement like https://github.com/DANS-KNAW/easy-fedora-to-bag/blob/4a4b7689e44aa0bb9c4c45dee8123899bfcd3de5/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala#L188
+    //   but that breaks https://github.com/DANS-KNAW/easy-fedora-to-bag/blob/2a47e60e8a267c00e1863f3e6e72172d4abd2e8f/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala#L952
+    Try(emdUnmarshaller.unmarshal( printer.format(Utility.trim(emdXml))))
       .getOrRecover(e => fail("could not load test EMD", e))
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/EmdSupport.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/EmdSupport.scala
@@ -23,20 +23,22 @@ import nl.knaw.dans.pf.language.emd.binding.EmdUnmarshaller
 import org.scalatest.Assertions._
 
 import scala.util.Try
-import scala.xml.{ Elem, NodeSeq }
+import scala.xml.{ Elem, NodeSeq, Utility }
 
 trait EmdSupport {
   private val emdUnmarshaller = new EmdUnmarshaller(classOf[EasyMetadataImpl])
   val abrMapping: AbrMappings = AbrMappings(File("src/main/assembly/dist/cfg/EMD_acdm.xsl"))
 
+
   def parseEmdContent(xml: NodeSeq): EasyMetadataImpl = {
-    val emd = <emd:easymetadata xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/"
+    val emdXml = <emd:easymetadata xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/"
                           xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/"
                           xmlns:dct="http://purl.org/dc/terms/"
                           xmlns:dc="http://purl.org/dc/elements/1.1/"
                           emd:version="0.1"
-        >{ xml }</emd:easymetadata>.serialize
-    Try(emdUnmarshaller.unmarshal(emd))
+        >{ xml }</emd:easymetadata>
+    val emdString = emdXml.serialize.split("\n").tail.mkString("\n").trim //drop prologue
+    Try(emdUnmarshaller.unmarshal(emdString))
       .getOrRecover(e => fail("could not load test EMD", e))
   }
 


### PR DESCRIPTION
Fixes DD-412: preserve white space in XML

#### When applied it will...
* preserve white space in the DDM
* **NB** unit tests that assemble a custom EMD don't preserve white space, see commit with quick and dirty fix
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
