### PR TITLE
DD-396: prevent identical original-versioned bags

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -37,7 +37,7 @@ import org.apache.commons.csv.CSVPrinter
 import org.joda.time.DateTime
 
 import java.io.{ IOException, InputStream }
-import java.nio.file.{ Path, Paths }
+import java.nio.file.Paths
 import java.util.UUID
 import javax.naming.ldap.InitialLdapContext
 import scala.collection.JavaConverters._
@@ -222,14 +222,12 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       isOriginalVersioned = options.transformationType == ORIGINAL_VERSIONED
       fileInfosForSecondBag = allFileInfos.selectForSecondBag(isOriginalVersioned)
       fileInfosForFirstBag <- allFileInfos.selectForFirstBag(emdXml, fileInfosForSecondBag.nonEmpty, options.europeana)
-      (forFirstBag, forSecondBag) <- FileInfo.checkDuplicateFiles(
-        fileInfosForFirstBag, FileInfo.forSecondBag(fileInfosForFirstBag, fileInfosForSecondBag), isOriginalVersioned
-      )
+      (forFirstBag, forSecondBag) <- FileInfo.checkDuplicateFiles(fileInfosForFirstBag, fileInfosForSecondBag, isOriginalVersioned)
       _ = logger.debug(s"nextFileInfos = ${ fileInfosForSecondBag.map(_.path) }")
       fileItemsForFirstBag <- forFirstBag.toList.traverse(addPayloadFileTo(bag, isOriginalVersioned))
       _ <- checkNotImplementedFileMetadata(fileItemsForFirstBag, logger)
       _ <- addXmlMetadataTo(bag, "files.xml")(filesXml(fileItemsForFirstBag))
-      _ = logger.debug(s"${fileInfosForSecondBag.map(_.path)} --- ${forSecondBag.map(_.path)}")
+      _ = logger.debug(s"${ fileInfosForSecondBag.map(_.path) } --- ${ forSecondBag.map(_.path) }")
       _ <- bag.save
       doi = emd.getEmdIdentifier.getDansManagedDoi
       urn = getUrn(datasetId, emd)

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -208,9 +208,6 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ <- getMessageFromDepositor(foXml)
         .map(addXmlMetadataTo(bag, "depositor-info/message-from-depositor.txt"))
         .getOrElse(Success(()))
-      _ <- getFilesXml(foXml)
-        .map(addXmlMetadataTo(bag, "original/files.xml"))
-        .getOrElse(Success(()))
       _ <- getAgreementsXml(foXml)
         .map(addAgreementsTo(bag))
         .getOrElse(AgreementsXml(foXml, ldap)
@@ -218,6 +215,9 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ <- managedMetadataStream(foXml, "ADDITIONAL_LICENSE", bag, "license")
         .getOrElse(Success(()))
       _ <- managedMetadataStream(foXml, "DATASET_LICENSE", bag, "depositor-info/depositor-agreement")
+        .getOrElse(Success(()))
+      _ <- getFilesXml(foXml)
+        .map(addXmlMetadataTo(bag, "original/files.xml"))
         .getOrElse(Success(()))
       isOriginalVersioned = options.transformationType == ORIGINAL_VERSIONED
       fileInfosForSecondBag = allFileInfos.selectForSecondBag(isOriginalVersioned)
@@ -228,10 +228,10 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       fileItemsForFirstBag <- fileInfosForFirstBag.traverse(addPayloadFileTo(bag, isOriginalVersioned))
       _ <- checkNotImplementedFileMetadata(fileItemsForFirstBag, logger)
       _ <- addXmlMetadataTo(bag, "files.xml")(filesXml(fileItemsForFirstBag))
+      _ = logger.debug(s"${fileInfosForSecondBag.map(_.path)} --- ${forSecondBag.map(_.path)}")
       _ <- bag.save
       doi = emd.getEmdIdentifier.getDansManagedDoi
       urn = getUrn(datasetId, emd)
-      _ = logger.debug(s"${fileInfosForSecondBag.map(_.path)} --- ${forSecondBag.map(_.path)}")
     } yield DatasetInfo(maybeFilterViolations, doi, urn, depositor, forSecondBag)
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -222,10 +222,11 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       isOriginalVersioned = options.transformationType == ORIGINAL_VERSIONED
       fileInfosForSecondBag = allFileInfos.selectForSecondBag(isOriginalVersioned)
       fileInfosForFirstBag <- allFileInfos.selectForFirstBag(emdXml, fileInfosForSecondBag.nonEmpty, options.europeana)
-      forSecondBag = FileInfo.forSecondBag(fileInfosForFirstBag, fileInfosForSecondBag)
-      _ <- FileInfo.checkDuplicateFiles(fileInfosForFirstBag, forSecondBag, isOriginalVersioned)
+      (forFirstBag, forSecondBag) <- FileInfo.checkDuplicateFiles(
+        fileInfosForFirstBag, FileInfo.forSecondBag(fileInfosForFirstBag, fileInfosForSecondBag), isOriginalVersioned
+      )
       _ = logger.debug(s"nextFileInfos = ${ fileInfosForSecondBag.map(_.path) }")
-      fileItemsForFirstBag <- fileInfosForFirstBag.traverse(addPayloadFileTo(bag, isOriginalVersioned))
+      fileItemsForFirstBag <- forFirstBag.toList.traverse(addPayloadFileTo(bag, isOriginalVersioned))
       _ <- checkNotImplementedFileMetadata(fileItemsForFirstBag, logger)
       _ <- addXmlMetadataTo(bag, "files.xml")(filesXml(fileItemsForFirstBag))
       _ = logger.debug(s"${fileInfosForSecondBag.map(_.path)} --- ${forSecondBag.map(_.path)}")

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -106,9 +106,7 @@ object FileInfo extends DebugEnhancedLogging {
     val fileInfosForSecondBag = forSecondBag(fileInfosForFirstBag, selectedForSecondBag)
     val duplicatesForFirstBag = findDuplicates(fileInfosForFirstBag)
     val duplicatesForSecondBag = findDuplicates(fileInfosForSecondBag)
-    if (duplicatesForFirstBag.isEmpty && duplicatesForSecondBag.isEmpty)
-      Success((fileInfosForFirstBag, fileInfosForSecondBag))
-    else {
+    if (duplicatesForFirstBag.nonEmpty || duplicatesForSecondBag.nonEmpty) {
       val prefix1 = "duplicates in first bag: "
       val prefix2 = "duplicates in second bag: "
       logDuplicates(prefix1, duplicatesForFirstBag)
@@ -116,6 +114,9 @@ object FileInfo extends DebugEnhancedLogging {
       Failure(InvalidTransformationException(
         s"$prefix1${ duplicatesForFirstBag.keys.mkString(", ") }; $prefix2${ duplicatesForSecondBag.keys.mkString(", ") } (isOriginalVersioned==$isOriginalVersioned)"
       ))
+    }
+    else {
+      Success((fileInfosForFirstBag, fileInfosForSecondBag))
     }
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -93,7 +93,7 @@ object FileInfo extends DebugEnhancedLogging {
     else second
   }
 
-  def checkDuplicateFiles(fileInfosForFirstBag: Seq[FileInfo], fileInfosForSecondBag: Seq[FileInfo], isOriginalVersioned: Boolean): Try[Unit] = {
+  def checkDuplicateFiles(fileInfosForFirstBag: Seq[FileInfo], fileInfosForSecondBag: Seq[FileInfo], isOriginalVersioned: Boolean): Try[(Seq[FileInfo], Seq[FileInfo])] = {
     def findDuplicates(fileInfos: Seq[FileInfo]) = fileInfos
       .groupBy(_.bagPath(isOriginalVersioned))
       .filter(_._2.size > 1)
@@ -105,7 +105,8 @@ object FileInfo extends DebugEnhancedLogging {
 
     val duplicatesForFirstBag = findDuplicates(fileInfosForFirstBag)
     val duplicatesForSecondBag = findDuplicates(fileInfosForSecondBag)
-    if (duplicatesForFirstBag.isEmpty && duplicatesForSecondBag.isEmpty) Success(())
+    if (duplicatesForFirstBag.isEmpty && duplicatesForSecondBag.isEmpty)
+      Success((fileInfosForFirstBag, fileInfosForSecondBag))
     else {
       val prefix1 = "duplicates in first bag: "
       val prefix2 = "duplicates in second bag: "

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -16,7 +16,6 @@
 package nl.knaw.dans.easy.fedoratobag
 
 import java.nio.file.{ Path, Paths }
-
 import scala.util.Try
 import scala.xml.Node
 
@@ -39,6 +38,13 @@ case class FileInfo(fedoraFileId: String,
   def bagPath(isOriginalVersioned: Boolean): Path =
     if (isOriginalVersioned && isOriginal) path.subpath(1, path.getNameCount)
     else path
+
+  private def versionedInfo: FileInfo = this.copy(
+    path = this.bagPath(true),
+    fedoraFileId = "",
+    accessibleTo = "",
+    visibleTo = "",
+  )
 }
 
 object FileInfo {
@@ -47,6 +53,13 @@ object FileInfo {
   def replaceNonAllowedCharacters(s: String): String = {
     s.map(char => if (nonAllowedCharacters.contains(char)) '_'
                   else char)
+  }
+
+  def forSecondBag(first: Seq[FileInfo], second: Seq[FileInfo]): Seq[FileInfo] = {
+    val a = first.map(_.versionedInfo)
+    val b = second.map(_.versionedInfo)
+    if (a == b) Seq.empty
+    else second
   }
 
   def apply(foXml: Node): Try[FileInfo] = {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -86,14 +86,14 @@ object FileInfo extends DebugEnhancedLogging {
   }
 
 
-  def forSecondBag(first: Seq[FileInfo], second: Seq[FileInfo]): Seq[FileInfo] = {
+  private def forSecondBag(first: Seq[FileInfo], second: Seq[FileInfo]): Seq[FileInfo] = {
     val a = first.map(_.versionedInfo)
     val b = second.map(_.versionedInfo)
     if (a == b) Seq.empty
     else second
   }
 
-  def checkDuplicateFiles(fileInfosForFirstBag: Seq[FileInfo], fileInfosForSecondBag: Seq[FileInfo], isOriginalVersioned: Boolean): Try[(Seq[FileInfo], Seq[FileInfo])] = {
+  def checkDuplicateFiles(fileInfosForFirstBag: Seq[FileInfo], selectedForSecondBag: Seq[FileInfo], isOriginalVersioned: Boolean): Try[(Seq[FileInfo], Seq[FileInfo])] = {
     def findDuplicates(fileInfos: Seq[FileInfo]) = fileInfos
       .groupBy(_.bagPath(isOriginalVersioned))
       .filter(_._2.size > 1)
@@ -103,6 +103,7 @@ object FileInfo extends DebugEnhancedLogging {
         ).mkString("[", ",", "]")
       )
 
+    val fileInfosForSecondBag = forSecondBag(fileInfosForFirstBag, selectedForSecondBag)
     val duplicatesForFirstBag = findDuplicates(fileInfosForFirstBag)
     val duplicatesForSecondBag = findDuplicates(fileInfosForSecondBag)
     if (duplicatesForFirstBag.isEmpty && duplicatesForSecondBag.isEmpty)

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -85,14 +85,6 @@ object FileInfo extends DebugEnhancedLogging {
     }
   }
 
-
-  private def forSecondBag(first: Seq[FileInfo], second: Seq[FileInfo]): Seq[FileInfo] = {
-    val a = first.map(_.versionedInfo)
-    val b = second.map(_.versionedInfo)
-    if (a == b) Seq.empty
-    else second
-  }
-
   def checkDuplicateFiles(fileInfosForFirstBag: Seq[FileInfo], selectedForSecondBag: Seq[FileInfo], isOriginalVersioned: Boolean): Try[(Seq[FileInfo], Seq[FileInfo])] = {
     def findDuplicates(fileInfos: Seq[FileInfo]) = fileInfos
       .groupBy(_.bagPath(isOriginalVersioned))
@@ -103,9 +95,8 @@ object FileInfo extends DebugEnhancedLogging {
         ).mkString("[", ",", "]")
       )
 
-    val fileInfosForSecondBag = forSecondBag(fileInfosForFirstBag, selectedForSecondBag)
     val duplicatesForFirstBag = findDuplicates(fileInfosForFirstBag)
-    val duplicatesForSecondBag = findDuplicates(fileInfosForSecondBag)
+    val duplicatesForSecondBag = findDuplicates(selectedForSecondBag)
     if (duplicatesForFirstBag.nonEmpty || duplicatesForSecondBag.nonEmpty) {
       val prefix1 = "duplicates in first bag: "
       val prefix2 = "duplicates in second bag: "
@@ -116,8 +107,15 @@ object FileInfo extends DebugEnhancedLogging {
       ))
     }
     else {
-      Success((fileInfosForFirstBag, fileInfosForSecondBag))
+      Success((fileInfosForFirstBag, forSecondBag(fileInfosForFirstBag, selectedForSecondBag)))
     }
+  }
+
+  private def forSecondBag(first: Seq[FileInfo], second: Seq[FileInfo]): Seq[FileInfo] = {
+    val a = first.map(_.versionedInfo)
+    val b = second.map(_.versionedInfo)
+    if (a == b) Seq.empty
+    else second
   }
 
   private def logDuplicates(prefix: String, duplicates: Map[Path, String]): Unit = {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/package.scala
@@ -40,7 +40,6 @@ package object fedoratobag {
 
   private val prologue = """<?xml version='1.0' encoding='UTF-8'?>"""
   private val logPrinter = new PrettyPrinter(-1, 0)
-  val printer = new PrettyPrinter(160, 2)
 
   implicit class XmlExtensions(val elem: Node) extends AnyVal {
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -109,7 +109,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     }
   }
 
-  it should "skip the identical second bag" in {
+  it should "produce the second bag as first and only" in {
     val app = new AppWithMockedServices() {
       Map(
         "easy-discipline:77" -> audienceFoXML("easy-discipline:77", "D13200"),
@@ -122,7 +122,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
       Seq(
         (1, "easy-dataset:17", "ADDITIONAL_LICENSE", "lalala"),
         (1, "easy-dataset:17", "DATASET_LICENSE", "blablabla"),
-        (1, "easy-file:36", "EASY_FILE", "barbapappa"),
+        (1, "easy-file:37", "EASY_FILE", "barbapappa"),
       ).foreach { case (n, objectId, streamId, content) =>
         (fedoraProvider.disseminateDatastream(_: String, _: String)) expects(objectId, streamId
         ) returning managed(content.inputStream) repeat n

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -109,6 +109,49 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     }
   }
 
+  it should "skip the identical second bag" in {
+    val app = new AppWithMockedServices() {
+      Map(
+        "easy-discipline:77" -> audienceFoXML("easy-discipline:77", "D13200"),
+        "easy-dataset:17" -> XML.loadFile((sampleFoXML / "DepositApi.xml").toJava),
+        "easy-file:36" -> fileFoXml(id = 36, location = "original/x", visibleTo = "NONE", accessibleTo = "NONE", name = "b.txt", digest = digests("barbapappa")),
+        "easy-file:37" -> fileFoXml(id = 37, location = "x", accessibleTo = "ANONYMOUS", name = "b.txt", digest = digests("barbapappa")),
+      ).foreach { case (id, xml) =>
+        (fedoraProvider.loadFoXml(_: String)) expects id once() returning Success(xml)
+      }
+      Seq(
+        (1, "easy-dataset:17", "ADDITIONAL_LICENSE", "lalala"),
+        (1, "easy-dataset:17", "DATASET_LICENSE", "blablabla"),
+        (1, "easy-file:36", "EASY_FILE", "barbapappa"),
+      ).foreach { case (n, objectId, streamId, content) =>
+        (fedoraProvider.disseminateDatastream(_: String, _: String)) expects(objectId, streamId
+        ) returning managed(content.inputStream) repeat n
+      }
+      (fedoraProvider.getSubordinates(_: String)) expects "easy-dataset:17" once() returning
+        Success(Seq("easy-file:36", "easy-file:37"))
+    }
+    // end of mocking
+
+    val sw = new StringWriter()
+    app.createOriginalVersionedExport(
+      Iterator("easy-dataset:17"),
+      (testDir / "output").createDirectories,
+      Options(SimpleDatasetFilter(allowOriginalAndOthers = true), ORIGINAL_VERSIONED),
+      SIP
+    )(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
+
+    // post condition
+
+    sw.toString should fullyMatch regex
+      """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
+        |easy-dataset:17,.+,,10.17026/test-Iiib-z9p-4ywa,user001,original-versioned without second bag,OK
+        |""".stripMargin
+
+    // post condition: just one bag
+
+    (testDir / "output").list should have size 1
+  }
+
   it should "produce a single bag" in {
     val app = new AppWithMockedServices() {
       Map(

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -25,6 +25,7 @@ import scala.xml._
 
 class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport with SchemaSupport {
   System.setProperty("http.agent", "Test")
+  private val printer = new PrettyPrinter(160, 2)
 
   override val schema = "https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd"
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileInfosSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileInfosSpec.scala
@@ -43,6 +43,7 @@ class FileInfosSpec extends TestSupportFixture {
     val for1st = fileInfos.selectForFirstBag(<emd/>, for2nd.nonEmpty, europeana = false)
     for2nd shouldBe fileInfos.slice(1, 2)
     for1st shouldBe Success(fileInfos.slice(0, 1))
+    // identical files are filtered
   }
   it should "return files for one bag" in {
     val fileInfos = List(

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/FileFoXmlSupport.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/FileFoXmlSupport.scala
@@ -31,6 +31,7 @@ trait FileFoXmlSupport {
                 name: String = "something.txt",
                 mimeType: String = "text/plain",
                 size: Long = 30,
+                visibleTo: String = "ANONYMOUS",
                 accessibleTo: String = "RESTRICTED_REQUEST",
                 digest: String = "dd466d19481a28ba8577e7b3f029e496027a3309"
                ): Elem = {
@@ -60,7 +61,7 @@ trait FileFoXmlSupport {
                       <mimeType>{ mimeType }</mimeType>
                       <size>{ size }</size>
                       <creatorRole>DEPOSITOR</creatorRole>
-                      <visibleTo>ANONYMOUS</visibleTo>
+                      <visibleTo>{visibleTo}</visibleTo>
                       <accessibleTo>{accessibleTo}</accessibleTo>
                   </fimd:file-item-md>
               </foxml:xmlContent>


### PR DESCRIPTION
Fixes DD-396: prevent identical original-versioned bags

#### When applied it will...
* prevent identical original-versioned bags when both have the same set of files that only differ by (one of)`fedoraFileId, accessibleTo, visibleTo`
* whenever there would have been identical bags, the files will get all properties from the second bag
* whenever there are two bags, they both may still have files that are only different by the properties above


#### Where should the reviewer @DANS-KNAW/easy start?

The new unit test in AppSpec

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
