### PR TITLE
DD-429: new option: no payload

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Retrieves a dataset from Fedora and transforms it to an AIP bag conforming to DA
 SYNOPSIS
 --------
 
-    easy-fedora-to-bag {-d <dataset-id> | -i <dataset-ids-file>} -o <output-dir> [-s] [-l <log-file>] [-e] -f { AIP | SIP } <transformation>
+    easy-fedora-to-bag {-d <dataset-id> | -i <dataset-ids-file>} -o <output-dir> [-s] [-l <log-file>] [-e | -p] -f { AIP | SIP } <transformation>
 
 DESCRIPTION
 -----------
@@ -27,6 +27,7 @@ ARGUMENTS
      -l, --log-file  <arg>        The name of the logfile in csv format. If not provided a file
                                   easy-fedora-to-bag-<timestamp>.csv will be created in the home-dir of the user.
                                   (default = /home/vagrant/easy-fedora-to-bag-2020-02-02T20:20:02.000Z.csv)
+     -p, --no-payload             If provided, only the largest pdf/image will selected as payload.
      -o, --output-dir  <arg>      Empty directory that will be created if it doesn't exist. Successful bags (or 
                                   packages) will be moved to this directory.
      -f, --output-format  <arg>   Output format: AIP, SIP. 'SIP' is only implemented for simple, it creates the

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ ARGUMENTS
      -l, --log-file  <arg>        The name of the logfile in csv format. If not provided a file
                                   easy-fedora-to-bag-<timestamp>.csv will be created in the home-dir of the user.
                                   (default = /home/vagrant/easy-fedora-to-bag-2020-02-02T20:20:02.000Z.csv)
-     -p, --no-payload             If provided, only the largest pdf/image will selected as payload.
+     -p, --no-payload             If provided, no payload files will be exported, i.e. only the metadata is present in the bag.
      -o, --output-dir  <arg>      Empty directory that will be created if it doesn't exist. Successful bags (or 
                                   packages) will be moved to this directory.
      -f, --output-format  <arg>   Output format: AIP, SIP. 'SIP' is only implemented for simple, it creates the

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,8 @@ ARGUMENTS
      -l, --log-file  <arg>        The name of the logfile in csv format. If not provided a file
                                   easy-fedora-to-bag-<timestamp>.csv will be created in the home-dir of the user.
                                   (default = /home/vagrant/easy-fedora-to-bag-2020-02-02T20:20:02.000Z.csv)
-     -p, --no-payload             If provided, no payload files will be exported, i.e. only the metadata is present in the bag.
+     -p, --no-payload             If provided, no payload files will be exported, i.e. only the metadata is
+                                  present in the bag.
      -o, --output-dir  <arg>      Empty directory that will be created if it doesn't exist. Successful bags (or 
                                   packages) will be moved to this directory.
      -f, --output-format  <arg>   Output format: AIP, SIP. 'SIP' is only implemented for simple, it creates the

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
@@ -70,7 +70,7 @@ object Command extends App with DebugEnhancedLogging {
   }
 
   private def runExport(app: EasyFedoraToBagApp, datasetFilter: SimpleDatasetFilter) = {
-    val options = Options(datasetFilter, transformationType, commandLine.strictMode(), europeana)
+    val options = Options(datasetFilter, transformationType, commandLine.strictMode(), europeana, commandLine.noPayload())
     val printer = CsvRecord.printer(csvLogFile)
     if (transformationType == FEDORA_VERSIONED)
       printer.apply(app.createSequences(datasetIds, commandLine.outputDir(), options))

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/CommandLineOptions.scala
@@ -16,10 +16,9 @@
 package nl.knaw.dans.easy.fedoratobag
 
 import java.nio.file.Paths
-
 import better.files.File
 import nl.knaw.dans.easy.fedoratobag.OutputFormat.OutputFormat
-import nl.knaw.dans.easy.fedoratobag.TransformationType.{ FEDORA_VERSIONED, TransformationType }
+import nl.knaw.dans.easy.fedoratobag.TransformationType.{ FEDORA_VERSIONED, ORIGINAL_VERSIONED, TransformationType }
 import org.rogach.scallop.{ ScallopConf, ScallopOption, ValueConverter, singleArgConverter }
 
 import scala.xml.Properties
@@ -32,7 +31,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val description: String = s"""Tool for exporting datasets from Fedora and constructing Archival/Submission Information Packages."""
   val synopsis: String =
     s"""
-       |  easy-fedora-to-bag {-d <dataset-id> | -i <dataset-ids-file>} -o <output-dir> [-s] [-l <log-file>] [-e] -f { AIP | SIP } <transformation>
+       |  easy-fedora-to-bag {-d <dataset-id> | -i <dataset-ids-file>} -o <output-dir> [-s] [-l <log-file>] [-e | -p] -f { AIP | SIP } <transformation>
      """.stripMargin
 
   version(s"$printedName v${ configuration.version }")
@@ -66,10 +65,13 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
     descr = "If provided, the transformation will check whether the datasets adhere to the requirements of the chosen transformation.")
   val europeana: ScallopOption[Boolean] = opt(name = "europeana", short = 'e',
     descr = "If provided, only the largest pdf/image will selected as payload.")
+  val noPayload: ScallopOption[Boolean] = opt(name = "no-payload", short = 'p',
+    descr = "If provided, only the largest pdf/image will selected as payload.")
   val transformation: ScallopOption[TransformationType] = trailArg(name = "transformation", required = true,
     descr = TransformationType.values.mkString("The type of transformation used: ", ", ", "."))
 
   conflicts(datasetId, List(inputFile))
+  conflicts(noPayload, List(europeana))
   validateOpt(inputFile) {
     case Some(f) if !f.toJava.isFile => Left(s"$f does not exist or is not a file")
     case _ => Right(())
@@ -83,6 +85,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
     case (None, _) => Left(s"trailing argument 'transformation' is mandatory") // required so won't happen
     case (Some(FEDORA_VERSIONED), _) if inputFile.isEmpty => Left(s"argument 'input-file' is mandatory for $FEDORA_VERSIONED")
     case (Some(FEDORA_VERSIONED), _) => Right(())
+    case (Some(ORIGINAL_VERSIONED), _) if noPayload.isDefined => Left(s"no-payload conflicts with fedora-versioned")
     case (Some(t), None) => Left(s"argument 'output-dir' is mandatory for $t")
     case (_, Some(dir)) =>
       if (dir.exists) {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/CommandLineOptions.scala
@@ -66,7 +66,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val europeana: ScallopOption[Boolean] = opt(name = "europeana", short = 'e',
     descr = "If provided, only the largest pdf/image will selected as payload.")
   val noPayload: ScallopOption[Boolean] = opt(name = "no-payload", short = 'p',
-    descr = "If provided, only the largest pdf/image will selected as payload.")
+    descr = "If provided, no payload files will be exported, i.e. only the metadata is present in the bag.")
   val transformation: ScallopOption[TransformationType] = trailArg(name = "transformation", required = true,
     descr = TransformationType.values.mkString("The type of transformation used: ", ", ", "."))
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -221,8 +221,8 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
         .map(addXmlMetadataTo(bag, "original/files.xml"))
         .getOrElse(Success(()))
       isOriginalVersioned = options.transformationType == ORIGINAL_VERSIONED
-      selectedForSecondBag = allFileInfos.selectForSecondBag(isOriginalVersioned)
-      selectedForFirstBag <- allFileInfos.selectForFirstBag(emdXml, selectedForSecondBag.nonEmpty, options.europeana)
+      selectedForSecondBag = allFileInfos.selectForSecondBag(isOriginalVersioned, options.noPayload)
+      selectedForFirstBag <- allFileInfos.selectForFirstBag(emdXml, selectedForSecondBag.nonEmpty, options.europeana, options.noPayload)
       (forFirstBag, forSecondBag) <- checkDuplicates(selectedForFirstBag, selectedForSecondBag, isOriginalVersioned)
       fileItemsForFirstBag <- forFirstBag.toList.traverse(addPayloadFileTo(bag, isOriginalVersioned))
       _ <- checkNotImplementedFileMetadata(fileItemsForFirstBag, logger)

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
@@ -28,4 +28,5 @@ case class Options(datasetFilter: DatasetFilter,
                    transformationType: TransformationType = SIMPLE,
                    strict: Boolean = true,
                    europeana: Boolean = false,
+                   noPayload: Boolean = false,
                   )

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileInfosSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileInfosSpec.scala
@@ -55,6 +55,18 @@ class FileInfosSpec extends TestSupportFixture {
     for2nd shouldBe empty
     for1st shouldBe Success(fileInfos)
   }
+  it should "return no files" in {
+    val fileInfos = List(
+      fileInfo.copy(fedoraFileId = "easy-file:1", path = Paths.get("rabarbera/x.txt")),
+      fileInfo.copy(fedoraFileId = "easy-file:2"),
+    )
+    // though commandline does not allow isOriginalVersioned nor europeana
+    // together with noPayload, the latter gets highest priority
+    val for2nd = fileInfos.selectForSecondBag(isOriginalVersioned = true, noPayload = true)
+    val for1st = fileInfos.selectForFirstBag(<emd/>, for2nd.nonEmpty, europeana = true, noPayload = true)
+    for2nd shouldBe empty
+    for1st shouldBe Success(Seq.empty)
+  }
   "Fileinfo" should "replace non allowed characters in name and filepath with '_'" in {
     val fileMetadata = {
       <name>a:c*e?g>i|k;m#o".txt</name>


### PR DESCRIPTION
Fixes DD-429: new option: no payload

#### When applied it will...
* no unit test is added yet
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

deploy and run on deasy:

    easy-fedora-to-bag -p -d 'easy-dataset:9' -o /vagrant/shared/xxx -f SIP simple

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
