### PR TITLE
DD-447: was derived from

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -263,7 +263,6 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
   }
 
   private def getFileInfo(fedoraFileId: String): Try[FileInfo] = {
-    trace(fedoraFileId)
     fedoraProvider
       .loadFoXml(fedoraFileId)
       .flatMap(FileInfo(_))

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -196,7 +196,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ = trace("created DDM from EMD")
       fedoraIDs <- if (options.noPayload) Success(Seq.empty)
                    else fedoraProvider.getSubordinates(datasetId)
-      allFileInfos <- fedoraIDs.filter(_.startsWith("easy-file:")).toList.traverse(getFileInfo)
+      allFileInfos <- FileInfo(fedoraIDs.filter(_.startsWith("easy-file:")).toList, fedoraProvider).map(_.toList)
       maybeFilterViolations <- options.datasetFilter.violations(emd, ddm, amd, fedoraIDs, allFileInfos)
       _ = if (options.strict) maybeFilterViolations.foreach(msg => throw InvalidTransformationException(msg))
       _ = logger.info(s"Creating $bagDir from $datasetId with owner $depositor")
@@ -260,15 +260,6 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
 
   private def addAgreementsTo(bag: DansV0Bag)(content: Node): Try[Any] = {
     bag.addTagFile(content.serialize.inputStream, Paths.get(s"metadata/depositor-info/agreements.xml"))
-  }
-
-  private def getFileInfo(fedoraFileId: String): Try[FileInfo] = {
-    fedoraProvider
-      .loadFoXml(fedoraFileId)
-      .flatMap(FileInfo(_))
-      .recoverWith {
-        case t: Throwable => Failure(new Exception(s"$fedoraFileId ${ t.getMessage }"))
-      }
   }
 
   private def addPayloadFileTo(bag: DansV0Bag, isOriginalVersioned: Boolean)(fileInfo: FileInfo): Try[Node] = {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FedoraProvider.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FedoraProvider.scala
@@ -62,13 +62,7 @@ class FedoraProvider(fedoraClient: FedoraClient) extends DebugEnhancedLogging {
       .flatMap(response => managed(response.getEntityInputStream))
   }
 
-  def datastream(objectId: String, streamId: String): ManagedResource[InputStream] = {
-    managed(FedoraClient.getDatastream(objectId, streamId).execute(fedoraClient))
-      .flatMap(response => managed(response.getEntityInputStream))
-  }
-
   def loadFoXml(objectId: String): Try[Elem] = {
-    trace(objectId)
     getObject(objectId).map(XML.load).tried
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -104,7 +104,7 @@ object FileInfo extends DebugEnhancedLogging {
           def get(tag: String) = (fileMetadata \\ tag)
             .map(_.text)
             .headOption
-            .getOrElse(throw new Exception(s"<$tag> not found"))
+            .getOrElse(throw new Exception(s"$fileId <$tag> not found"))
 
           val visibleTo = get("visibleTo")
           val accessibleTo = if ("NONE" == visibleTo.toUpperCase) "NONE"

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -83,7 +83,10 @@ object FileInfo extends DebugEnhancedLogging {
             .map(p => Paths.get(replaceNonAllowedCharacters(p)))
         } yield (fileId, derivedFromId, digest, fileMetadata, path)
       }.map { files =>
-      val pathMap = files.map { case (fileId, _, _, _, path) => fileId -> path }.toMap
+      val pathMap = files.map {
+        case (fileId, _, _, _, maybePath) =>
+          fileId -> maybePath.map(p => Paths.get("data/" + p))
+      }.toMap
       files.map {
         case (fileId, _, _, _, None) =>
           throw new Exception(s"<path> not found for $fileId")

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.fedoratobag
 
 import com.typesafe.scalalogging.Logger
 
+import java.nio.file.Path
 import java.util.Locale
 import scala.util.{ Failure, Success, Try }
 import scala.xml._
@@ -52,17 +53,23 @@ object FileItem {
   }
 
   def apply(fileInfo: FileInfo, isOriginalVersioned: Boolean): Try[Node] = Try {
+    val src = fileInfo.wasDerivedForm.map(path =>
+        <dcterms:source xmlns="http://purl.org/dc/terms/">{ path.toString }</dcterms:source>
+    ).getOrElse(new Text(""))
     val bagPath = fileInfo.bagPath(isOriginalVersioned)
-      <file filepath={ "data/" + fileInfo.bagPath(isOriginalVersioned) }>{
-          if (bagPath != fileInfo.path) Comment(fileInfo.path.toString)
-          else Text("")
-        }<dct:identifier>{ fileInfo.fedoraFileId }</dct:identifier>
+    val comment = if (bagPath != fileInfo.path) Comment(fileInfo.path.toString)
+                  else Text("")
+
+      <file filepath={ "data/" + fileInfo.bagPath(isOriginalVersioned) }>
+        { comment }
+        <dct:identifier>{ fileInfo.fedoraFileId }</dct:identifier>
         <dct:title>{ fileInfo.name }</dct:title>
         <dct:format>{ fileInfo.mimeType }</dct:format>
         <dct:extent>{ "%.1fMB".formatLocal(Locale.US, fileInfo.size / 1024 / 1024) }</dct:extent>
         { fileInfo.additionalMetadata.map(convert).getOrElse(Seq[Node]()) }
         <accessibleToRights>{ fileInfo.accessibleTo }</accessibleToRights>
         <visibleToRights>{ fileInfo.visibleTo }</visibleToRights>
+        { src }
       </file>
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
@@ -54,8 +54,8 @@ object FileItem {
 
   def apply(fileInfo: FileInfo, isOriginalVersioned: Boolean): Try[Node] = Try {
     val src = fileInfo.wasDerivedForm.map(path =>
-        <dcterms:source xmlns="http://purl.org/dc/terms/">{ path.toString }</dcterms:source>
-    ).getOrElse(new Text(""))
+        <dct:source>{ path.toString }</dct:source>
+    ).getOrElse(Seq[Node]())
     val bagPath = fileInfo.bagPath(isOriginalVersioned)
     val comment = if (bagPath != fileInfo.path) Comment(fileInfo.path.toString)
                   else Text("")
@@ -66,7 +66,7 @@ object FileItem {
         <dct:title>{ fileInfo.name }</dct:title>
         <dct:format>{ fileInfo.mimeType }</dct:format>
         <dct:extent>{ "%.1fMB".formatLocal(Locale.US, fileInfo.size / 1024 / 1024) }</dct:extent>
-        { fileInfo.additionalMetadata.map(convert).getOrElse(Seq[Node]()) }
+        { fileInfo.additionalMetadata.map(convert).getOrElse( Seq[Node]()) }
         <accessibleToRights>{ fileInfo.accessibleTo }</accessibleToRights>
         <visibleToRights>{ fileInfo.visibleTo }</visibleToRights>
         { src }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
@@ -53,14 +53,14 @@ object FileItem {
   }
 
   def apply(fileInfo: FileInfo, isOriginalVersioned: Boolean): Try[Node] = Try {
-    val src = fileInfo.wasDerivedForm.map(path =>
-        <dct:source>{ path.toString }</dct:source>
+    val src = fileInfo.bagSource(isOriginalVersioned).map(path =>
+        <dct:source>{ "data/" + path }</dct:source>
     ).getOrElse(Seq[Node]())
     val bagPath = fileInfo.bagPath(isOriginalVersioned)
     val comment = if (bagPath != fileInfo.path) Comment(fileInfo.path.toString)
                   else Text("")
 
-      <file filepath={ "data/" + fileInfo.bagPath(isOriginalVersioned) }>
+      <file filepath={ "data/" + bagPath }>
         { comment }
         <dct:identifier>{ fileInfo.fedoraFileId }</dct:identifier>
         <dct:title>{ fileInfo.name }</dct:title>

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FoXml.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FoXml.scala
@@ -69,7 +69,6 @@ object FoXml extends DebugEnhancedLogging {
   def getMessageFromDepositor(foXml: Node): Option[Node] = getStreamRoot("message-from-depositor.txt", foXml)
 
   def managedStreamLabel(foXml: Node, id: String): Option[String] = {
-    trace(id)
     getStreamRoot(id, foXml)
       .withFilter(hasControlGroup("M"))
       .flatMap(getLabel)

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -378,7 +378,8 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    app.createBag("easy-dataset:13", bagDir, Options(app.filter)) should matchPattern {
+    val triedInfo = app.createBag("easy-dataset:13", bagDir, Options(app.filter))
+    triedInfo should matchPattern {
       case Failure(e) if e.getMessage == "easy-file:35 <visibleTo> not found" =>
     }
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileInfosSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileInfosSpec.scala
@@ -16,13 +16,13 @@
 package nl.knaw.dans.easy.fedoratobag
 
 import nl.knaw.dans.easy.fedoratobag.filter._
-import nl.knaw.dans.easy.fedoratobag.fixture.TestSupportFixture
+import nl.knaw.dans.easy.fedoratobag.fixture.{ FileFoXmlSupport, TestSupportFixture }
 
 import java.nio.file.Paths
 import scala.util.Success
 import scala.xml.NodeBuffer
 
-class FileInfosSpec extends TestSupportFixture {
+class FileInfosSpec extends TestSupportFixture with FileFoXmlSupport {
   private val fileInfo = new FileInfo("easy-file:1", Paths.get("x.txt"), "x.txt", size = 2, mimeType = "text/plain", accessibleTo = "ANONYMOUS", visibleTo = "ANONYMOUS", contentDigest = None, additionalMetadata = None)
   "selectForXxxBag" should "return files for two bags" in {
     val fileInfos = List(
@@ -68,32 +68,10 @@ class FileInfosSpec extends TestSupportFixture {
     for1st shouldBe Success(Seq.empty)
   }
   "Fileinfo" should "replace non allowed characters in name and filepath with '_'" in {
-    val fileMetadata = {
-      <name>a:c*e?g>i|k;m#o".txt</name>
-      <path>p:t*/t?/s>m|w;e#e/a:c*e?g>i|k;m#o".txt</path>
-      <mimeType>text/plain</mimeType>
-      <size>911988</size>
-      <creatorRole>ARCHIVIST</creatorRole>
-      <visibleTo>ANONYMOUS</visibleTo>
-      <accessibleTo>KNOWN</accessibleTo>
-    }
-    def fileFoXml(fileMetadata: NodeBuffer) = {
-      <foxml:digitalObject VERSION="1.1" PID="easy-file:35"
-             xmlns:foxml="info:fedora/fedora-system:def/foxml#"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
-          <foxml:datastream ID="EASY_FILE_METADATA" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
-              <foxml:datastreamVersion ID="EASY_FILE_METADATA.0" LABEL="" CREATED="2020-03-17T10:24:17.660Z" MIMETYPE="text/xml" SIZE="359">
-                  <foxml:xmlContent>
-                      <fimd:file-item-md xmlns:addmd="http://easy.dans.knaw.nl/easy/additional-metadata/" xmlns:fimd="http://easy.dans.knaw.nl/easy/file-item-md/" version="0.1">
-                          { fileMetadata }
-                      </fimd:file-item-md>
-                  </foxml:xmlContent>
-              </foxml:datastreamVersion>
-          </foxml:datastream>
-      </foxml:digitalObject>
-    }
-    val fileInfo = FileInfo(fileFoXml(fileMetadata)).get
+    val fileInfo = FileInfo(fileFoXml(
+      location="p:t*/t?/s>m|w;e#e",
+      name = "a:c*e?g>i|k;m#o\".txt",
+    )).get
     fileInfo.name shouldBe "a_c_e_g_i_k_m_o_.txt"
     fileInfo.path shouldBe Paths.get("p_t_/t_/s_m_w_e_e/a_c_e_g_i_k_m_o_.txt")
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
@@ -150,7 +150,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
       "easy-file:35" -> fileFoXml(fileMetadata),
     )) should matchPattern {
       case Failure(e: Exception) if e.getMessage ==
-        "<accessibleTo> not found" =>
+        "easy-file:35 <accessibleTo> not found" =>
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
@@ -62,7 +62,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
           <dct:extent>0.0MB</dct:extent>
           <accessibleToRights>RESTRICTED_REQUEST</accessibleToRights>
           <visibleToRights>ANONYMOUS</visibleToRights>
-          <dcterms:source xmlns="http://purl.org/dc/terms/">original/some.xlsx</dcterms:source>
+          <dct:source>original/some.xlsx</dct:source>
         </file>
       </files>
     )

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
@@ -31,30 +31,53 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
 
   private def validateItem(item: Node) = validate(FileItem.filesXml(Seq(item)))
 
-  "filesXml" should "" in {
-    val derivedFiles = callFileInfo(Map(
-      "easy-file:2" -> fileFoXml(id = 2, name = "some.xlsx"),
-      "easy-file:25" -> fileFoXml(id = 25, name = "some.csv", location = "curated", creatorRole = "ARCHIVIST", derivedFrom = Some(2)),
-    )).getOrElse(fail("could not load test data"))
+  private val derivedFiles = callFileInfo(Map(
+    "easy-file:2" -> fileFoXml(id = 2, location = "cu*rated", name = "so:me.xlsx"),
+    "easy-file:25" -> fileFoXml(id = 25, name = "so:me.csv", creatorRole = "ARCHIVIST", derivedFrom = Some(2)),
+  )).getOrElse(fail("could not load test data"))
 
+  "filesXml" should "drop original in <dct:source>" in {
     val fileItems = derivedFiles.map(FileItem(_, isOriginalVersioned = true).get)
     normalized(FileItem.filesXml(fileItems)) shouldBe normalized(
       <files xsi:schemaLocation={ location } xmlns={ ns }>
-        <file filepath="data/some.xlsx">
-          <!--original/some.xlsx-->
+        <file filepath="data/cu_rated/so_me.xlsx">
           <dct:identifier>easy-file:2</dct:identifier>
-          <dct:title>some.xlsx</dct:title>
+          <dct:title>so_me.xlsx</dct:title>
           <dct:format>text/plain</dct:format>
           <dct:extent>0.0MB</dct:extent>
           <accessibleToRights>RESTRICTED_REQUEST</accessibleToRights>
           <visibleToRights>ANONYMOUS</visibleToRights>
-        </file><file filepath="data/curated/some.csv"><dct:identifier>easy-file:25</dct:identifier>
-          <dct:title>some.csv</dct:title>
+          <dct:source>data/so_me.xlsx</dct:source>
+        </file><file filepath="data/so_me.csv"><dct:identifier>easy-file:25</dct:identifier>
+          <!--original/so_me.csv-->
+          <dct:title>so_me.csv</dct:title>
           <dct:format>text/plain</dct:format>
           <dct:extent>0.0MB</dct:extent>
           <accessibleToRights>RESTRICTED_REQUEST</accessibleToRights>
           <visibleToRights>ANONYMOUS</visibleToRights>
-          <dct:source>original/some.xlsx</dct:source>
+        </file>
+      </files>
+    )
+  }
+  it should "keep original in <dct:source>" in {
+    val fileItems = derivedFiles.map(FileItem(_, isOriginalVersioned = false).get)
+    normalized(FileItem.filesXml(fileItems)) shouldBe normalized(
+      <files xsi:schemaLocation={ location } xmlns={ ns }>
+        <file filepath="data/cu_rated/so_me.xlsx">
+          <dct:identifier>easy-file:2</dct:identifier>
+          <dct:title>so_me.xlsx</dct:title>
+          <dct:format>text/plain</dct:format>
+          <dct:extent>0.0MB</dct:extent>
+          <accessibleToRights>RESTRICTED_REQUEST</accessibleToRights>
+          <visibleToRights>ANONYMOUS</visibleToRights>
+          <dct:source>data/original/so_me.xlsx</dct:source>
+        </file><file filepath="data/original/so_me.csv">
+          <dct:identifier>easy-file:25</dct:identifier>
+          <dct:title>so_me.csv</dct:title>
+          <dct:format>text/plain</dct:format>
+          <dct:extent>0.0MB</dct:extent>
+          <accessibleToRights>RESTRICTED_REQUEST</accessibleToRights>
+          <visibleToRights>ANONYMOUS</visibleToRights>
         </file>
       </files>
     )

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
@@ -32,29 +32,30 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
   private def validateItem(item: Node) = validate(FileItem.filesXml(Seq(item)))
 
   private val derivedFiles = callFileInfo(Map(
-    "easy-file:2" -> fileFoXml(id = 2, location = "cu*rated", name = "so:me.xlsx"),
-    "easy-file:25" -> fileFoXml(id = 25, name = "so:me.csv", creatorRole = "ARCHIVIST", derivedFrom = Some(2)),
+    "easy-file:2" -> fileFoXml(id = 2, name = "so:me.xslx", creatorRole = "ARCHIVIST"),
+    "easy-file:25" -> fileFoXml(id = 25, location = "cu*rated", name = "so:me.csv", derivedFrom = Some(2)),
   )).getOrElse(fail("could not load test data"))
 
   "filesXml" should "drop original in <dct:source>" in {
     val fileItems = derivedFiles.map(FileItem(_, isOriginalVersioned = true).get)
     normalized(FileItem.filesXml(fileItems)) shouldBe normalized(
       <files xsi:schemaLocation={ location } xmlns={ ns }>
-        <file filepath="data/cu_rated/so_me.xlsx">
+        <file filepath="data/so_me.xslx">
+          <!--original/so_me.xslx-->
           <dct:identifier>easy-file:2</dct:identifier>
-          <dct:title>so_me.xlsx</dct:title>
+          <dct:title>so_me.xslx</dct:title>
           <dct:format>text/plain</dct:format>
           <dct:extent>0.0MB</dct:extent>
           <accessibleToRights>RESTRICTED_REQUEST</accessibleToRights>
           <visibleToRights>ANONYMOUS</visibleToRights>
-          <dct:source>data/so_me.xlsx</dct:source>
-        </file><file filepath="data/so_me.csv"><dct:identifier>easy-file:25</dct:identifier>
-          <!--original/so_me.csv-->
+        </file>
+        <file filepath="data/cu_rated/so_me.csv"><dct:identifier>easy-file:25</dct:identifier>
           <dct:title>so_me.csv</dct:title>
           <dct:format>text/plain</dct:format>
           <dct:extent>0.0MB</dct:extent>
           <accessibleToRights>RESTRICTED_REQUEST</accessibleToRights>
           <visibleToRights>ANONYMOUS</visibleToRights>
+          <dct:source>data/so_me.xslx</dct:source>
         </file>
       </files>
     )
@@ -63,21 +64,21 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
     val fileItems = derivedFiles.map(FileItem(_, isOriginalVersioned = false).get)
     normalized(FileItem.filesXml(fileItems)) shouldBe normalized(
       <files xsi:schemaLocation={ location } xmlns={ ns }>
-        <file filepath="data/cu_rated/so_me.xlsx">
+        <file filepath="data/original/so_me.xslx">
           <dct:identifier>easy-file:2</dct:identifier>
-          <dct:title>so_me.xlsx</dct:title>
+          <dct:title>so_me.xslx</dct:title>
           <dct:format>text/plain</dct:format>
           <dct:extent>0.0MB</dct:extent>
           <accessibleToRights>RESTRICTED_REQUEST</accessibleToRights>
           <visibleToRights>ANONYMOUS</visibleToRights>
-          <dct:source>data/original/so_me.xlsx</dct:source>
-        </file><file filepath="data/original/so_me.csv">
+        </file><file filepath="data/cu_rated/so_me.csv">
           <dct:identifier>easy-file:25</dct:identifier>
           <dct:title>so_me.csv</dct:title>
           <dct:format>text/plain</dct:format>
           <dct:extent>0.0MB</dct:extent>
           <accessibleToRights>RESTRICTED_REQUEST</accessibleToRights>
           <visibleToRights>ANONYMOUS</visibleToRights>
+          <dct:source>data/original/so_me.xslx</dct:source>
         </file>
       </files>
     )

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/FileFoXmlSupport.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/FileFoXmlSupport.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.fedoratobag.fixture
 
-import scala.xml.Elem
+import scala.xml.{ Elem, Text }
 
 trait FileFoXmlSupport {
 
@@ -33,7 +33,9 @@ trait FileFoXmlSupport {
                 size: Long = 30,
                 visibleTo: String = "ANONYMOUS",
                 accessibleTo: String = "RESTRICTED_REQUEST",
-                digest: String = "dd466d19481a28ba8577e7b3f029e496027a3309"
+                digest: String = "dd466d19481a28ba8577e7b3f029e496027a3309",
+                creatorRole: String = "DEPOSITOR",
+                derivedFrom: Option[Int] = None,
                ): Elem = {
     <foxml:digitalObject VERSION="1.1" PID={s"easy-file:$id"}
                      xmlns:foxml="info:fedora/fedora-system:def/foxml#"
@@ -60,10 +62,31 @@ trait FileFoXmlSupport {
                       <path>{s"$location/$name"}</path>
                       <mimeType>{ mimeType }</mimeType>
                       <size>{ size }</size>
-                      <creatorRole>DEPOSITOR</creatorRole>
+                      <creatorRole>{creatorRole}</creatorRole>
                       <visibleTo>{visibleTo}</visibleTo>
                       <accessibleTo>{accessibleTo}</accessibleTo>
                   </fimd:file-item-md>
+              </foxml:xmlContent>
+          </foxml:datastreamVersion>
+      </foxml:datastream>
+      <foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+          <foxml:datastreamVersion ID="RELS-EXT.2" LABEL="rels-ext" CREATED="2019-04-29T08:51:00.905Z" MIMETYPE="text/xml" FORMAT_URI="info:fedora/fedora-system:FedoraRELSExt-1.0" SIZE="784">
+              <foxml:xmlContent>
+                  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+
+                      <rdf:Description rdf:about="info:fedora/easy-file:2707296">
+                          <isSubordinateTo xmlns="http://dans.knaw.nl/ontologies/relations#" rdf:resource="info:fedora/easy-dataset:46287"></isSubordinateTo>
+                          <isMemberOf xmlns="http://dans.knaw.nl/ontologies/relations#" rdf:resource="info:fedora/easy-folder:142970"></isMemberOf>
+                          <hasModel xmlns="info:fedora/fedora-system:def/model#" rdf:resource="info:fedora/easy-model:EDM1FILE"></hasModel>
+                          <hasModel xmlns="info:fedora/fedora-system:def/model#" rdf:resource="info:fedora/dans-container-item-v1"></hasModel>
+                        { derivedFrom.map(id =>
+
+                          <wasDerivedFrom xmlns="https://www.w3.org/TR/2012/CR-prov-o-20121211/#" rdf:resource={s"info:fedora/easy-file:$id"}></wasDerivedFrom>
+                      ).getOrElse(new Text(""))
+                        }
+                      </rdf:Description>
+
+                  </rdf:RDF>
               </foxml:xmlContent>
           </foxml:datastreamVersion>
       </foxml:datastream>


### PR DESCRIPTION
Fixes DD-447: was derived from

#### When applied it will...
* add `<dct:source>` to `files.xml` based on `<wasDerivedFrom ... rdf:resource=...>` in RELS-EXT of file foXML
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
