### PR TITLE
DD-523: no payload for datasets with more than X files

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,11 +19,14 @@ An AIP is a [DANS-V0 bag], a SIP is a directory with a bag and a `deposit.proper
 ARGUMENTS
 ---------
 
+     -c, --cutoff  <arg>          No payload files will be exported, when the dataset has more files than the
+                                  specified value. (default = 2147483647)
      -d, --datasetId  <arg>       A single easy-dataset-id to be transformed. Use either this or the input-file
                                   argument
      -e, --europeana              If provided, only the largest pdf/image will selected as payload.
      -i, --input-file  <arg>      File containing a newline-separated list of easy-dataset-ids to be transformed.
-                                  Use either this or the dataset-id argument
+                                  Use either this or the dataset-id argument. Lines starting with '#' are
+                                  ignored.
      -l, --log-file  <arg>        The name of the logfile in csv format. If not provided a file
                                   easy-fedora-to-bag-<timestamp>.csv will be created in the home-dir of the user.
                                   (default = /home/vagrant/easy-fedora-to-bag-2020-02-02T20:20:02.000Z.csv)

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
@@ -23,7 +23,6 @@ import nl.knaw.dans.easy.fedoratobag.versions.FedoraVersions
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
-import scala.collection.mutable.ListBuffer
 import scala.language.reflectiveCalls
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -71,7 +70,7 @@ object Command extends App with DebugEnhancedLogging {
   }
 
   private def runExport(app: EasyFedoraToBagApp, datasetFilter: SimpleDatasetFilter) = {
-    val options = Options(datasetFilter, transformationType, commandLine.strictMode(), europeana, commandLine.noPayload())
+    val options = Options(datasetFilter, transformationType, commandLine.strictMode(), europeana, commandLine.noPayload(), commandLine.cutoff())
     val printer = CsvRecord.printer(csvLogFile)
     if (transformationType == FEDORA_VERSIONED)
       printer.apply(app.createSequences(datasetIds, commandLine.outputDir(), options))

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
@@ -78,13 +78,13 @@ object Command extends App with DebugEnhancedLogging {
   }
 
   private def datasetIds: Iterator[DatasetId] = {
-    val skip = commandLine.skipDatasets.toOption.toList.flatMap(_.lines)
+    val skip = commandLine.skipDatasets.toOption.toList.flatMap(_.lines).filterNot(_.trim.isEmpty)
     commandLine
       .datasetId.map(Iterator(_))
       .getOrElse(commandLine
         .inputFile()
         .lineIterator
-        .filterNot(_.startsWith("#"))
+        .filterNot(line => line.startsWith("#") || line.trim.isEmpty)
         .filterNot(skip.contains(_))
       )
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/CommandLineOptions.scala
@@ -15,12 +15,12 @@
  */
 package nl.knaw.dans.easy.fedoratobag
 
-import java.nio.file.Paths
 import better.files.File
 import nl.knaw.dans.easy.fedoratobag.OutputFormat.OutputFormat
 import nl.knaw.dans.easy.fedoratobag.TransformationType.{ FEDORA_VERSIONED, ORIGINAL_VERSIONED, TransformationType }
 import org.rogach.scallop.{ ScallopConf, ScallopOption, ValueConverter, singleArgConverter }
 
+import java.nio.file.Paths
 import scala.xml.Properties
 
 class CommandLineOptions(args: Array[String], configuration: Configuration) extends ScallopConf(args) {
@@ -53,7 +53,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val datasetId: ScallopOption[DatasetId] = opt(name = "datasetId", short = 'd',
     descr = "A single easy-dataset-id to be transformed. Use either this or the input-file argument")
   val inputFile: ScallopOption[File] = opt(name = "input-file", short = 'i',
-    descr = "File containing a newline-separated list of easy-dataset-ids to be transformed. Use either this or the dataset-id argument")
+    descr = "File containing a newline-separated list of easy-dataset-ids to be transformed. Use either this or the dataset-id argument. Lines starting with '#' are ignored.")
   val skipDatasets: ScallopOption[File] = opt(name = "skip-list",
     descr = s"File containing a newline-separated list of easy-dataset-ids to be skipped")
   val outputDir: ScallopOption[File] = opt(name = "output-dir", short = 'o',
@@ -69,6 +69,8 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
     descr = "If provided, only the largest pdf/image will selected as payload.")
   val noPayload: ScallopOption[Boolean] = opt(name = "no-payload", short = 'p',
     descr = "If provided, no payload files will be exported, i.e. only the metadata is present in the bag.")
+  val cutoff: ScallopOption[Int] = opt(name = "cutoff", short = 'c', required = false, default = Some(Int.MaxValue),
+    descr = "No payload files will be exported, when the dataset has more files than the specified value.")
   val transformation: ScallopOption[TransformationType] = trailArg(name = "transformation", required = true,
     descr = TransformationType.values.mkString("The type of transformation used: ", ", ", "."))
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/CsvRecord.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/CsvRecord.scala
@@ -15,14 +15,13 @@
  */
 package nl.knaw.dans.easy.fedoratobag
 
-import java.io.IOException
-import java.util.UUID
-
 import better.files.{ Dispose, File }
 import nl.knaw.dans.easy.fedoratobag.Command.FeedBackMessage
 import nl.knaw.dans.easy.fedoratobag.TransformationType.ORIGINAL_VERSIONED
 import org.apache.commons.csv.{ CSVFormat, CSVPrinter }
 
+import java.io.IOException
+import java.util.UUID
 import scala.util.Try
 
 case class CsvRecord(easyDatasetId: DatasetId,
@@ -56,6 +55,8 @@ object CsvRecord {
     val violations = datasetInfo.maybeFilterViolations
     val comment = if (violations.isEmpty) "OK"
                   else violations.mkString("")
+    val commentSuffix = if (datasetInfo.withPayload && !options.noPayload) ""
+                        else s"; no payload, nr of files exceeds ${ options.cutoff }"
     val typePrefix = violations.map(_ => "not strict ").getOrElse("")
     val typeSuffix = uuid2.map(_ => "")
       .getOrElse(
@@ -70,7 +71,7 @@ object CsvRecord {
       datasetInfo.doi,
       datasetInfo.depositor,
       typePrefix + options.transformationType + typeSuffix,
-      comment,
+      comment + commentSuffix,
     )
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.fedoratobag
 
 import nl.knaw.dans.common.lang.dataset.AccessCategory._
+import nl.knaw.dans.easy.fedoratobag.DDM.lang
 import nl.knaw.dans.easy.fedoratobag.DateMap.isOtherDate
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.string._
@@ -33,7 +34,7 @@ object DDM extends DebugEnhancedLogging {
   val dansLicense = "http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf"
   val cc0 = "http://creativecommons.org/publicdomain/zero/1.0"
 
-  def apply(emd: EasyMetadataImpl, audiences: Seq[String], abrMapping: AbrMappings): Try[Elem] = Try {
+  def apply(emd: EasyMetadataImpl, audiences: Seq[String], abrMapping: AbrMappings, payloadInEasy: Node = Text("")): Try[Elem] = Try {
     //    println(new EmdMarshaller(emd).getXmlString)
 
     val dateMap: Map[String, Seq[Elem]] = DateMap(emd)
@@ -70,6 +71,7 @@ object DDM extends DebugEnhancedLogging {
        { emd.getEmdIdentifier.getDcIdentifier.asScala.map(bi => <dct:identifier xsi:type={ idType(bi) }>{ bi.getValue.trim }</dct:identifier>) }
        { emd.getEmdTitle.getDcTitle.asScala.drop(1).map(bs => <dc:title xml:lang={ lang(bs) }>{ bs.getValue.trim }</dc:title>) }
        { emd.getEmdTitle.getTermsAlternative.asScala.map(str => <dct:alternative>{ str }</dct:alternative>) }
+       { payloadInEasy }
        { emd.getEmdDescription.getTermsAbstract.asScala.map(bs => <ddm:description xml:lang={ lang(bs) } descriptionType='Abstract'>{ bs.getValue.trim }</ddm:description>) }
        { emd.getEmdDescription.getTermsTableOfContents.asScala.map(bs => <ddm:description xml:lang={ lang(bs) } descriptionType='TableOfContents'>{ bs.getValue.trim }</ddm:description>) }
        { emd.getEmdRelation.getDCRelationMap.asScala.map { case (key, values) => values.asScala.map(toRelationXml(key, _)) } }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DatasetInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DatasetInfo.scala
@@ -20,4 +20,5 @@ case class DatasetInfo(maybeFilterViolations: Option[String],
                        urn: String,
                        depositor: Depositor,
                        nextBagFileInfos: Seq[FileInfo] = Seq.empty,
+                       withPayload: Boolean,
                       )

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -237,7 +237,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ <- bag.save
       doi = emd.getEmdIdentifier.getDansManagedDoi
       urn = getUrn(datasetId, emd)
-    } yield DatasetInfo(maybeFilterViolations, doi, urn, depositor, forSecondBag)
+    } yield DatasetInfo(maybeFilterViolations, doi, urn, depositor, forSecondBag, withPayLoad)
   }
 
   private def getUrn(datasetId: DatasetId, emd: EasyMetadataImpl) = {

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
@@ -29,4 +29,5 @@ case class Options(datasetFilter: DatasetFilter,
                    strict: Boolean = true,
                    europeana: Boolean = false,
                    noPayload: Boolean = false,
+                   cutoff: Int = Int.MaxValue,
                   )

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -339,7 +339,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
     app.createBag("easy-dataset:13", bagDir, Options(app.filter)) shouldBe
-      Success(DatasetInfo(None, "10.17026/mocked-Iiib-z9p-4ywa", "urn:nbn:nl:ui:13-blablabla", "user001", Seq.empty))
+      Success(DatasetInfo(None, "10.17026/mocked-Iiib-z9p-4ywa", "urn:nbn:nl:ui:13-blablabla", "user001", Seq.empty, withPayload = true))
 
     // post conditions
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -263,13 +263,6 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
       (fedoraProvider.getSubordinates(_: String)) expects "easy-dataset:17" once() returning
         Success(Seq("easy-jumpoff:1"))
       Map(
-        "ADDITIONAL_LICENSE" -> "lalala",
-        "DATASET_LICENSE" -> "blablabla",
-      ).foreach { case (streamId, content) =>
-        (fedoraProvider.disseminateDatastream(_: String, _: String)) expects("easy-dataset:17", streamId
-        ) once() returning managed(content.inputStream)
-      }
-      Map(
         "easy-discipline:77" -> audienceFoXML("easy-discipline:77", "D13200"),
         "easy-dataset:17" -> XML.loadFile((sampleFoXML / "DepositApi.xml").toJava),
       ).foreach { case (id, xml) =>
@@ -286,22 +279,17 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     // post conditions
 
-    val metadata = (testDir / "bags").children.next() / "metadata"
-    (metadata / "depositor-info/depositor-agreement.pdf").contentAsString shouldBe "blablabla"
-    (metadata / "license.pdf").contentAsString shouldBe "lalala"
-    metadata.list.toSeq.map(_.name).sortBy(identity) shouldBe
-      Seq("amd.xml", "dataset.xml", "depositor-info", "emd.xml", "license.pdf", "original")
-    (metadata / "depositor-info").list.toSeq.map(_.name).sortBy(identity) shouldBe
-      Seq("agreements.xml", "depositor-agreement.pdf", "message-from-depositor.txt")
+    (testDir / "bags") shouldNot exist
   }
 
   it should "report strict simple violation" in {
     val app = new AppWithMockedServices() {
       (fedoraProvider.getSubordinates(_: String)) expects "easy-dataset:17" once() returning
-        Success(Seq("dans-jumpoff:1"))
+        Success(Seq("dans-jumpoff:1", "easy-file:37"))
       Map(
         "easy-discipline:77" -> audienceFoXML("easy-discipline:77", "D13200"),
         "easy-dataset:17" -> XML.loadFile((sampleFoXML / "DepositApi.xml").toJava),
+        "easy-file:37" -> fileFoXml(id = 37, location = "x", accessibleTo = "ANONYMOUS", name = "b.txt", digest = digests("barbapappa")),
       ).foreach { case (id, xml) =>
         (fedoraProvider.loadFoXml(_: String)) expects id once() returning Success(xml)
       }
@@ -533,7 +521,6 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
   it should "cause NoPayloadFilesException" in {
     val app: AppWithMockedServices = new AppWithMockedServices() {
-      expectAUser()
       (fedoraProvider.getSubordinates(_: String)) expects "easy-dataset:13" once() returning
         Success(Seq("easy-file:1", "easy-file:5"))
       val foXMLs = Map(

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateExportSpec.scala
@@ -33,10 +33,10 @@ class CreateExportSpec extends TestSupportFixture with DelegatingApp with FileFo
     val sw = new StringWriter()
 
     val createBagExpects = Seq(
-      "easy-dataset:1" -> Success(DatasetInfo(None, "mocked-doi1", "", "user001")),
+      "easy-dataset:1" -> Success(DatasetInfo(None, "mocked-doi1", "", "user001", withPayload = true)),
       "easy-dataset:2" -> Failure(InvalidTransformationException("mocked")),
       "easy-dataset:3" -> Failure(new Exception("easy-dataset:3")),
-      "easy-dataset:4" -> Success(DatasetInfo(None, "mocked-doi4", "", "user001")),
+      "easy-dataset:4" -> Success(DatasetInfo(None, "mocked-doi4", "", "user001", withPayload = true)),
     )
 
     // end of mocking
@@ -70,8 +70,8 @@ class CreateExportSpec extends TestSupportFixture with DelegatingApp with FileFo
     val outputDir = (testDir / "output").createDirectories()
     val sw = new StringWriter()
     val createBagExpects = Seq(
-      "easy-dataset:1" -> Success(DatasetInfo(None, "mocked-doi1", "", "testUser")),
-      "easy-dataset:2" -> Success(DatasetInfo(None, "mocked-doi2", "", "testUser")),
+      "easy-dataset:1" -> Success(DatasetInfo(None, "mocked-doi1", "", "testUser", withPayload = true)),
+      "easy-dataset:2" -> Success(DatasetInfo(None, "mocked-doi2", "", "testUser", withPayload = true)),
     )
 
     // end of mocking
@@ -101,10 +101,10 @@ class CreateExportSpec extends TestSupportFixture with DelegatingApp with FileFo
     val outputDir = (testDir / "output").createDirectories()
     val sw = new StringWriter()
     val createBagExpects = Seq(
-      "easy-dataset:1" -> Success(DatasetInfo(None, "mocked-doi1", "", "testUser")),
+      "easy-dataset:1" -> Success(DatasetInfo(None, "mocked-doi1", "", "testUser", withPayload = true)),
       "easy-dataset:2" -> Failure(new Exception("easy-dataset:2")),
       "easy-dataset:3" -> Failure(InvalidTransformationException("mocked")),
-      "easy-dataset:4" -> Success(DatasetInfo(None, "mocked-doi4", "", "testUser")),
+      "easy-dataset:4" -> Success(DatasetInfo(None, "mocked-doi4", "", "testUser", withPayload = true)),
       "easy-dataset:5" -> Failure(new FedoraClientException(300, "mocked exception")),
     )
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateSequenceSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateSequenceSpec.scala
@@ -37,7 +37,7 @@ class CreateSequenceSpec extends TestSupportFixture with DelegatingApp with File
   "createSequences" should " process 2 sequences" in {
     val sw = new StringWriter()
     val createBagExpects = (1 to 5).map(i =>
-      s"easy-dataset:$i" -> Success(DatasetInfo(None, s"mocked-doi$i", "mocked-urn", "user001"))
+      s"easy-dataset:$i" -> Success(DatasetInfo(None, s"mocked-doi$i", "mocked-urn", "user001", withPayload = true))
     )
     // end of mocking
 
@@ -92,15 +92,15 @@ class CreateSequenceSpec extends TestSupportFixture with DelegatingApp with File
   it should "not abort on a metadata rule violation" in {
     val sw = new StringWriter()
     val createBagExpects = Seq(
-      "easy-dataset:1" -> Success(DatasetInfo(Some("Violates something"), "mocked-doi", "", "user001")),
+      "easy-dataset:1" -> Success(DatasetInfo(Some("Violates something"), "mocked-doi", "", "user001", withPayload = true)),
       "easy-dataset:10" -> Failure(InvalidTransformationException("Violates whatever")),
       // the two mocked results above mix a strict and non-strict run in a single test
-      "easy-dataset:2" -> Success(DatasetInfo(None, "mocked-doi", "", "user001")),
-      "easy-dataset:3" -> Success(DatasetInfo(None, "mocked-doi", "", "user001")),
+      "easy-dataset:2" -> Success(DatasetInfo(None, "mocked-doi", "", "user001", withPayload = true)),
+      "easy-dataset:3" -> Success(DatasetInfo(None, "mocked-doi", "", "user001", withPayload = true)),
       "easy-dataset:4" -> Failure(new FedoraClientException(404, "mocked not found")),
-      "easy-dataset:5" -> Success(DatasetInfo(None, "mocked-doi", "", "user001")),
+      "easy-dataset:5" -> Success(DatasetInfo(None, "mocked-doi", "", "user001", withPayload = true)),
       "easy-dataset:6" -> Failure(new IllegalArgumentException("mocked error")),
-      "easy-dataset:8" -> Success(DatasetInfo(None, "mocked-doi", "", "user001")),
+      "easy-dataset:8" -> Success(DatasetInfo(None, "mocked-doi", "", "user001", withPayload = true)),
       "easy-dataset:9" -> Failure(new IOException("mocked error")),
     )
 


### PR DESCRIPTION
Fixes DD-523: no payload for datasets with more than X files

#### When applied it will...
* [x] have unit tests to show the change
* 
* 

#### Where should the reviewer @DANS-KNAW/easy @DANS-KNAW/dataversedans  start?

#### How should this be manually tested?

run for all deasy datasets with `-c 3`. One of the CSV lines is something like 

    easy-dataset:12,<UUID>,,<DOI>,user001,fedora-versioned,"OK; no payload, nr of files exceeds 3"

The log contains something like :

    [2021-06-28 15:04:38,306] INFO  Creating /... from easy-dataset:12 with owner user001
    [2021-06-28 15:04:38,351] WARN  too many files 12, 0

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
