### PR TITLE
DD-585: not:implemented should result in FAILED

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
@@ -172,7 +172,7 @@ object DDM extends DebugEnhancedLogging {
 
   private def notImplemented(msg: String)(data: Any): Elem = {
     logger.error(s"not implemented $msg [$data]")
-    <not:implemented/>
+    <not:implemented>{s"$msg: ${data.toString.trim}"}</not:implemented>
   }
 
   /** a null value skips rendering the attribute */

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -222,6 +222,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ = trace("created DDM from EMD")
       maybeFilterViolations <- options.datasetFilter.violations(emd, ddm, amd, fedoraIDs, allFileInfos)
       _ = if (options.strict) maybeFilterViolations.foreach(msg => throw InvalidTransformationException(msg))
+      _ = if ((ddm \\ "implemented").filter(_.prefix == "not").nonEmpty) throw InvalidTransformationException("not:implemented in the DDM")
       // so far for collecting data, now we start writing
       _ = logger.info(s"Creating $bagDir from $datasetId with owner $depositor")
       bag <- DansV0Bag.empty(bagDir)

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -222,7 +222,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ = trace("created DDM from EMD")
       maybeFilterViolations <- options.datasetFilter.violations(emd, ddm, amd, fedoraIDs, allFileInfos)
       _ = if (options.strict) maybeFilterViolations.foreach(msg => throw InvalidTransformationException(msg))
-      _ = if ((ddm \\ "implemented").filter(_.prefix == "not").nonEmpty) throw InvalidTransformationException("not:implemented in the DDM")
+      _ = (ddm \\ "implemented").filter(_.prefix == "not").foreach(n => throw InvalidTransformationException(n.toString()))
       // so far for collecting data, now we start writing
       _ = logger.info(s"Creating $bagDir from $datasetId with owner $depositor")
       bag <- DansV0Bag.empty(bagDir)

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -525,7 +525,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
     app.createBag("easy-dataset:13", bagDir, Options(app.filter)) shouldBe
-      Failure(InvalidTransformationException("not:implemented in the DDM"))
+      Failure(InvalidTransformationException("<not:implemented>invalid box: SpatialBox(Some(RD),None,None,None,None)</not:implemented>"))
   }
 
   it should "export largest image as payload" in {

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -507,6 +507,27 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     }
   }
 
+  it should "report not:implemented node" in {
+    val foXml = XML.loadFile((sampleFoXML / "streaming.xml").toJava).toString().replace("<emd:coverage/>", "<emd:coverage><eas:spatial><eas:box eas:scheme=\"RD\"></eas:box></eas:spatial></emd:coverage>")
+    val app: AppWithMockedServices = new AppWithMockedServices() {
+      (fedoraProvider.getSubordinates(_: String)) expects "easy-dataset:13" once() returning
+        Success(Seq("easy-file:1"))
+      val foXMLs = Map(
+        "easy-dataset:13" -> XML.loadString(foXml),
+        "easy-discipline:6" -> audienceFoXML("easy-discipline:6", "D35400"),
+        "easy-file:1" -> fileFoXml(id = 1, name = "a.txt", digest = digests("acabadabra")),
+      )
+      foXMLs.foreach { case (id, xml) =>
+        (fedoraProvider.loadFoXml(_: String)) expects id once() returning Success(xml)
+      }
+    }
+
+    // end of mocking
+    val bagDir = testDir / "bags" / UUID.randomUUID.toString
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter)) shouldBe
+      Failure(InvalidTransformationException("not:implemented in the DDM"))
+  }
+
   it should "export largest image as payload" in {
     val app: AppWithMockedServices = new AppWithMockedServices() {
       expectAUser()

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -793,8 +793,8 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>
         { ddmProfile("D35400") }
         <ddm:dcmiMetadata>
-          <not:implemented/>
-          <not:implemented/>
+          <not:implemented>invalid box: SpatialBox(Some(RD),None,None,None,None)</not:implemented>
+          <not:implemented>invalid box: SpatialBox(Some(degrees),None,None,None,None)</not:implemented>
           <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
         </ddm:dcmiMetadata>
       </ddm:DDM>
@@ -834,10 +834,12 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>
         { ddmProfile("D35400") }
         <ddm:dcmiMetadata>
-          <not:implemented/>
-          <not:implemented/>
-          <not:implemented/>
-          <not:implemented/>
+          <not:implemented>expected either point, box or polygon: name=A general description</not:implemented>
+          <not:implemented>expected either point, box or polygon: scheme=null x=1 y=nullscheme=degrees north=79.5 east=23.0 south=76.7 west=10.0</not:implemented>
+          <not:implemented>
+            expected either point, box or polygon: scheme=degrees north=79.5 east=23.0 south=76.7 west=10.0(exterior=null, interior=null)
+          </not:implemented>
+          <not:implemented>expected either point, box or polygon: scheme=null x=1 y=null(exterior=null, interior=null)</not:implemented>
           <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
         </ddm:dcmiMetadata>
       </ddm:DDM>
@@ -1059,7 +1061,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>
         { ddmProfile("D13200") }
         <ddm:dcmiMetadata>
-          <not:implemented/>
+          <not:implemented>relation (references): title=rababera URI=isbn:9053566937</not:implemented>
           <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
         </ddm:dcmiMetadata>
       </ddm:DDM>


### PR DESCRIPTION
Fixes DD-585

#### When applied it will...
* throw an exception when there is `not:implemented` node in the DDM

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
