### PR TITLE
DD-578: Remove Rule 2 from easy-fedora-to-bag violations

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/DatasetFilter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/DatasetFilter.scala
@@ -40,7 +40,6 @@ trait DatasetFilter extends DebugEnhancedLogging {
     val violations = Seq(
       "1: DANS DOI" -> (if (maybeDoi.isEmpty) Seq("not found")
                         else Seq[String]()),
-      "2: has jump off" -> fedoraIDs.filter(_.startsWith("dans-jumpoff:")),
       "3: invalid title" -> Option(emd.getEmdTitle.getPreferredTitle)
         .filter(title => forbiddenTitle(title)).toSeq,
       invalidStateKey -> findInvalidState(amd),

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DatasetFilterSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DatasetFilterSpec.scala
@@ -116,17 +116,6 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
       Success(Some("Violates 3: invalid title"))
   }
 
-  it should "report jump off" in {
-    val emdTitle = <emd:title><dc:title xml:lang="nld">thematische collectie</dc:title></emd:title>
-    val emd = parseEmdContent(Seq(emdTitle, emdDoi))
-
-    simpleChecker(loggerExpectsWarnings = Seq(
-      "violated 2: has jump off dans-jumpoff:123",
-      "violated 3: invalid title thematische collectie",
-    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq("dans-jumpoff:123")) shouldBe
-      Success(Some("Violates 2: has jump off; 3: invalid title"))
-  }
-
   it should "report invalid status" in {
     val emd = parseEmdContent(emdDoi)
 


### PR DESCRIPTION
Fixes DD-578

#### When applied it will...
* Remove rule 2 ("`has jump off`") from easy-fedora-to-bag `violations`
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
