### PR TITLE
DD-586: Make 'state' to be exported configurable

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -19,3 +19,6 @@ auth.ldap.password=ldapadmin
 # directory were a SIP is created,
 # once completed the SIP will be moved to the specified output-dir
 staging.dir=/var/opt/dans.knaw.nl/tmp/easy-fedora-to-bag/staged
+
+# states that are included in export
+export.states=SUBMITTED,PUBLISHED

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Configuration.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Configuration.scala
@@ -31,6 +31,7 @@ case class Configuration(version: String,
                          bagIndexUrl: URI,
                          stagingDir: File,
                          abrMapping: AbrMappings,
+                         exportStates: List[String],
                         )
 
 object Configuration {
@@ -68,6 +69,7 @@ object Configuration {
       new URI(properties.getString("bag-index.url")),
       File(properties.getString("staging.dir")),
       AbrMappings(cfgPath / "EMD_acdm.xsl"),
+      properties.getString("export.states").replace(" ", "").split(",").toList,
     )
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Configuration.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Configuration.scala
@@ -69,7 +69,7 @@ object Configuration {
       new URI(properties.getString("bag-index.url")),
       File(properties.getString("staging.dir")),
       AbrMappings(cfgPath / "EMD_acdm.xsl"),
-      properties.getString("export.states").replace(" ", "").split(",").toList,
+      properties.getString("export.states").split(",").toList.map(_.trim),
     )
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -221,7 +221,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ = trace("creating DDM from EMD")
       ddm <- DDM(emd, audiences, configuration.abrMapping, payloadInEasy(tooManyFiles))
       _ = trace("created DDM from EMD")
-      maybeFilterViolations <- options.datasetFilter.violations(emd, ddm, amd, fedoraIDs, allFileInfos)
+      maybeFilterViolations <- options.datasetFilter.violations(emd, ddm, amd, fedoraIDs, allFileInfos, configuration.exportStates)
       _ = if (options.strict) maybeFilterViolations.foreach(msg => throw InvalidTransformationException(msg))
       _ = (ddm \\ "implemented").filter(_.prefix == "not").foreach(n => throw InvalidTransformationException(n.toString()))
       // so far for collecting data, now we start writing

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/DatasetFilter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/DatasetFilter.scala
@@ -31,7 +31,7 @@ trait DatasetFilter extends DebugEnhancedLogging {
   val allowOriginalAndOthers: Boolean = false
   private val invalidStateKey = "5: invalid state"
 
-  def violations(emd: EasyMetadataImpl, ddm: Node, amd: Node, fedoraIDs: Seq[String] = Seq.empty, fileInfos: List[FileInfo] = List.empty): Try[Option[String]] = {
+  def violations(emd: EasyMetadataImpl, ddm: Node, amd: Node, fedoraIDs: Seq[String] = Seq.empty, fileInfos: List[FileInfo] = List.empty, exportStates: List[String]): Try[Option[String]] = {
     val maybeDoi = Option(emd.getEmdIdentifier.getDansManagedDoi)
     val mixOfOriginalAndOthers = allowOriginalAndOthers || !fileInfos.hasOriginalAndOthers
     val triedMaybeInTargetResponse: Try[Option[String]] = maybeDoi
@@ -43,7 +43,7 @@ trait DatasetFilter extends DebugEnhancedLogging {
       "2: has jump off" -> fedoraIDs.filter(_.startsWith("dans-jumpoff:")),
       "3: invalid title" -> Option(emd.getEmdTitle.getPreferredTitle)
         .filter(title => forbiddenTitle(title)).toSeq,
-      invalidStateKey -> findInvalidState(amd),
+      invalidStateKey -> findInvalidState(amd, exportStates),
       "6: DANS relations" -> findDansRelations(ddm).map(_.toOneLiner),
       "7: is in the vault" -> triedMaybeInTargetResponse.getOrElse(None).toSeq,
       "8: original and other files" -> (if (mixOfOriginalAndOthers) Seq.empty
@@ -65,11 +65,11 @@ trait DatasetFilter extends DebugEnhancedLogging {
 
   def forbiddenTitle(title: String): Boolean
 
-  private def findInvalidState(amd: Node) = {
+  private def findInvalidState(amd: Node, exportStates: List[String]) = {
     val seq = amd \ "datasetState"
     if (seq.isEmpty) Seq("not found")
     else seq
-      .withFilter(node => !(node.text == "PUBLISHED"))
+      .withFilter(node => !exportStates.contains(node.text))
       .map(_.text)
   }
 

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -13,3 +13,6 @@ auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=ldapadmin
 
 staging.dir=/var/opt/dans.knaw.nl/tmp/easy-fedora-to-bag/staged
+
+# states that are included in export
+export.states=SUBMITTED,PUBLISHED

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -34,7 +34,7 @@ import scala.xml.XML
 class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupport with MockFactory with FileSystemSupport with AudienceSupport {
   implicit val logFile: File = testDir / "log.txt"
 
-  private class AppWithMockedServices(configuration: Configuration = new Configuration("test-version", null, null, null, null, testDir / "staging", AbrMappings(File("src/main/assembly/dist/cfg/EMD_acdm.xsl"))),
+  private class AppWithMockedServices(configuration: Configuration = new Configuration("test-version", null, null, null, null, testDir / "staging", AbrMappings(File("src/main/assembly/dist/cfg/EMD_acdm.xsl")), List("PUBLISHED", "SUBMITTED")),
                                      ) extends EasyFedoraToBagApp(configuration) {
     private class MockedLdapContext extends InitialLdapContext(new java.util.Hashtable[String, String](), null)
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DatasetFilterSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DatasetFilterSpec.scala
@@ -30,6 +30,8 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
 
   private class MockedBagIndex extends BagIndex(new URI("http://localhost:20120/"))
 
+  private val exportStates = "PUBLISHED,SUBMITTED".split(",").toList
+
   private val emdRights = <emd:rights>
                             <dct:accessRights eas:schemeId="common.dcterms.accessrights"
                                 >REQUEST_PERMISSION</dct:accessRights>
@@ -45,7 +47,7 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     val emd = parseEmdContent(Seq(emdTitle, emdDoi, emdRights))
 
     themaChecker(loggerExpectsWarnings = Seq.empty)
-      .violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq()) shouldBe
+      .violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq(),List.empty, exportStates) shouldBe
       Success(None)
   }
 
@@ -55,7 +57,7 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
 
     themaChecker(loggerExpectsWarnings = Seq(
       "violated 3: invalid title some collection",
-    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq()) shouldBe
+    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq(),List.empty, exportStates) shouldBe
       Success(Some("Violates 3: invalid title"))
   }
 
@@ -69,7 +71,7 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
 
     simpleChecker(loggerExpectsWarnings = Seq(
       "violated 8: original and other files should not occur both",
-    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), fedoraIDs = Seq(), fileInfos) shouldBe
+    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), fedoraIDs = Seq(), fileInfos, exportStates) shouldBe
       Success(Some("Violates 8: original and other files"))
   }
 
@@ -82,18 +84,17 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
       "x.txt",
     ).map(p => new FileInfo("easy-file:2", Paths.get(p), "x.txt", 2, "text/plain", "ANONYMOUS", "ANONYMOUS", None, None))
 
-    FedoraVersionedFilter().violations(emd, ddm, amd("PUBLISHED"), fedoraIDs = Seq(), fileInfos) shouldBe
+    FedoraVersionedFilter().violations(emd, ddm, amd("PUBLISHED"), fedoraIDs = Seq(), fileInfos, exportStates) shouldBe
       Success(None)
     SimpleDatasetFilter(allowOriginalAndOthers = true)
-      .violations(emd, ddm, amd("PUBLISHED"), fedoraIDs = Seq(), fileInfos) shouldBe
+      .violations(emd, ddm, amd("PUBLISHED"), fedoraIDs = Seq(), fileInfos, exportStates) shouldBe
       Success(None)
   }
 
   "SimpleChecker.simpleViolations" should "succeed" in {
     val emdTitle = <emd:title><dc:title xml:lang="nld">no theme</dc:title></emd:title>
     val emd = parseEmdContent(Seq(emdTitle, emdDoi, emdRights))
-
-    simpleChecker(loggerExpectsWarnings = Seq(), mockBagIndexRespondsWith(body = "", code = 404)).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) shouldBe
+    simpleChecker(loggerExpectsWarnings = Seq(), mockBagIndexRespondsWith(body = "", code = 404)).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty, List.empty, exportStates) shouldBe
       Success(None)
   }
 
@@ -101,9 +102,8 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     val emd = parseEmdContent(emdRights)
     simpleChecker(loggerExpectsWarnings = Seq(
       "violated 1: DANS DOI not found",
-      "violated 5: invalid state SUBMITTED",
-    ), bagIndex = null).violations(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty) shouldBe
-      Success(Some("Violates 1: DANS DOI; 5: invalid state (SUBMITTED)"))
+    ), bagIndex = null).violations(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty,List.empty, exportStates) shouldBe
+      Success(Some("Violates 1: DANS DOI"))
   }
 
   it should "report thematische collectie" in {
@@ -112,7 +112,7 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
 
     simpleChecker(loggerExpectsWarnings = Seq(
       "violated 3: invalid title thematische collectie",
-    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq()) shouldBe
+    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq(),List.empty, exportStates) shouldBe
       Success(Some("Violates 3: invalid title"))
   }
 
@@ -123,16 +123,16 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     simpleChecker(loggerExpectsWarnings = Seq(
       "violated 2: has jump off dans-jumpoff:123",
       "violated 3: invalid title thematische collectie",
-    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq("dans-jumpoff:123")) shouldBe
+    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq("dans-jumpoff:123"),List.empty, exportStates) shouldBe
       Success(Some("Violates 2: has jump off; 3: invalid title"))
   }
 
   it should "report invalid status" in {
     val emd = parseEmdContent(emdDoi)
-
+    val exportStates = List("PUBLISHED")
     simpleChecker(loggerExpectsWarnings = Seq(
       "violated 5: invalid state SUBMITTED",
-    )).violations(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty) shouldBe
+    )).violations(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty,List.empty, exportStates) shouldBe
       Success(Some("Violates 5: invalid state (SUBMITTED)"))
   }
 
@@ -154,7 +154,7 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
       "violated 6: DANS relations <dct:isVersionOf>https://doi.org/10.17026/test-123-456</dct:isVersionOf>",
       "violated 6: DANS relations <dct:isVersionOf>http://www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-2ajw-cq</dct:isVersionOf>",
       """violated 6: DANS relations <ddm:replaces scheme="id-type:URN" href="http://persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-aka-hff">Prehistorische bewoning op het World Forum gebied - Den Haag (replaces)</ddm:replaces>""",
-    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) shouldBe
+    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty,List.empty, exportStates) shouldBe
       Success(Some("Violates 6: DANS relations"))
   }
 
@@ -164,7 +164,7 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     simpleChecker(
       loggerExpectsWarnings = Seq(s"violated 7: is in the vault $result"),
       mockBagIndexRespondsWith(body = s"<result>$result</result>", code = 200),
-    ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) shouldBe
+    ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty,List.empty, exportStates) shouldBe
       Success(Some("Violates 7: is in the vault"))
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/ReadmeSpec.scala
@@ -32,6 +32,7 @@ class ReadmeSpec extends TestSupportFixture with CustomMatchers with FixedCurren
     bagIndexUrl = null,
     stagingDir = null,
     abrMapping = null,
+    exportStates = null,
   )
   Properties.setProp("user.home", "/home/vagrant")
   private val clo = new CommandLineOptions(Array[String](), configuration) {

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
@@ -29,7 +29,7 @@ trait DelegatingApp extends MockFactory {
 
   /* delegate most of createBag to a mock to test the rest of the class and/or application */
   def delegatingApp(staging: File, createBagExpects: Seq[(String, Try[DatasetInfo])]): EasyFedoraToBagApp = new EasyFedoraToBagApp(
-    new Configuration("testVersion", null, null, null, new URI(""), staging, null)
+    new Configuration("testVersion", null, null, null, new URI(""), staging, null, null)
   ) {
     // mock requires a constructor without parameters
     class MockEasyFedoraToBagApp() extends EasyFedoraToBagApp(null) {


### PR DESCRIPTION
Fixes DD-586

#### When applied it will...
* make `states`, that are to be exported, `configurable`


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
