### PR TITLE
DD-598: protocol 'null' in URI

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
@@ -309,6 +309,7 @@ object DDM extends DebugEnhancedLogging {
     }.getOrElse {
       if (uri.toString.startsWith("10.17026/")) s"https://doi.org/$uri"
       else if (uri.toString.isBlank) null
+      else if (uri.toString.startsWith("www.")) "http://" + uri
            else uri.toString
     }
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -263,7 +263,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>
         { ddmProfile("D35400") }
         <ddm:dcmiMetadata>
-          <ddm:replaces href="www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-mp3-pb2">
+          <ddm:replaces href="http://www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-mp3-pb2">
             Vlaardingen
           </ddm:replaces>
           <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>


### PR DESCRIPTION
Fixes DD-598

#### When applied it will...
* add `protocol http` to uri's that start with `www`


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
