### PR TITLE
DD-638: Ignore empty eas:place in spatial

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
@@ -209,18 +209,20 @@ object DDM extends DebugEnhancedLogging {
   }
 
   private def toXml(spatial: Spatial): Node = {
+    def notExpected = notImplemented("expected either point, box or polygon")(spatial)
     ( Option(spatial.getPlace),
       Option(spatial.getPoint),
       Option(spatial.getBox),
       Option(spatial.getPolygons),
     ) match {
+      case (Some(s), _, _, _) if s.getValue.nonEmpty => notExpected
       case (_, None, None, Some(polygons)) if !polygons.isEmpty =>
         <dcx-gml:spatial>
           { toXml(polygons.asScala) }
         </dcx-gml:spatial>
       case (_, Some(_), None, None) => toXmlPoint(spatial.getPoint)
       case (_, None, Some(_), None) => toXml(spatial.getBox)
-      case _ => notImplemented("expected either point, box or polygon")(spatial)
+      case _ => notExpected
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DdmSpec.scala
@@ -541,8 +541,6 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
       emdRights,
     ))
     val triedDDM = DDM(emd, Seq("D35400"), abrMapping)
-    // logs: WARN  Empty point: scheme=RD x=null y=null
-    // note that a missing x or y defaults to zero
     triedDDM.map(normalized) shouldBe Success(normalized(
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>
         { ddmProfile("D35400") }
@@ -658,6 +656,35 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
     triedDDM.flatMap(validate) shouldBe Success(())
   }
 
+  it should "ignore place description" in {
+    val emd = parseEmdContent(Seq(
+      emdTitle, emdCreator, emdDescription, emdDates,
+        <emd:coverage>
+          <eas:spatial>
+            <eas:place>blablabla</eas:place>
+            <eas:box eas:scheme="degrees">
+              <eas:north>90.0</eas:north>
+              <eas:east>180.0</eas:east>
+              <eas:south>-90.0</eas:south>
+              <eas:west>-180.0</eas:west>
+            </eas:box>
+          </eas:spatial>
+        </emd:coverage>,
+      emdRights,
+    ))
+    val triedDDM = DDM(emd, Seq("D35400"), abrMapping)
+    triedDDM.map(normalized) shouldBe Success(normalized(
+      <ddm:DDM xsi:schemaLocation={ schemaLocation }>
+        { ddmProfile("D35400") }
+        <ddm:dcmiMetadata>
+           <not:implemented>expected either point, box or polygon: name=blablabla scheme=degrees north=90.0 east=180.0 south=-90.0 west=-180.0</not:implemented>
+           <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
+        </ddm:dcmiMetadata>
+      </ddm:DDM>
+      )
+    )
+  }
+
   it should "render a box with an srsName" in {
     val emd = parseEmdContent(Seq(
       emdTitle, emdCreator, emdDescription, emdDates,
@@ -692,9 +719,6 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
       emdRights,
     ))
     val triedDDM = DDM(emd, Seq("D35400"), abrMapping)
-    // logs
-    //  ERROR not implemented invalid box [SpatialBox(Some(RD),None,None,None,None)]
-    //  ERROR not implemented invalid box [SpatialBox(Some(degrees),None,None,None,None)]
     triedDDM.map(normalized) shouldBe Success(normalized(
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>
         { ddmProfile("D35400") }
@@ -773,9 +797,6 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
       emdRights,
     ))
     val triedDDM = DDM(emd, Seq("D35400"), abrMapping)
-    // logs
-    //  ERROR not implemented invalid box [SpatialBox(Some(RD),None,None,None,None)]
-    //  ERROR not implemented invalid box [SpatialBox(Some(degrees),None,None,None,None)]
     triedDDM.map(normalized) shouldBe Success(normalized(
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>
         { ddmProfile("D35400") }
@@ -836,10 +857,8 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
       emdRights,
     ))
     // logs
-    //  ERROR not implemented expected either point, box or polygon [name=A general description ]
-    //  ERROR not implemented expected either point, box or polygon [scheme=null x=1 y=nullscheme=degrees north=79.5 east=23.0 south=76.7 west=10.0]
-    //  ERROR not implemented expected either point, box or polygon [scheme=degrees north=79.5 east=23.0 south=76.7 west=10.0(exterior=null, interior=null) ]
-    //  ERROR not implemented expected either point, box or polygon [scheme=null x=1 y=null(exterior=null, interior=null) ]
+    //    ERROR not implemented invalid box [SpatialBox(Some(RD),None,None,None,None)]
+    //    ERROR not implemented invalid box [SpatialBox(Some(degrees),None,None,None,None)]    val triedDDM = DDM(emd, Seq("D35400"), abrMapping)
     val triedDDM = DDM(emd, Seq("D35400"), abrMapping)
     triedDDM.map(normalized) shouldBe Success(normalized(
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>
@@ -878,9 +897,10 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
       emdRights,
     ))
     // logs
-    //  ERROR not implemented  [subject 0]
-    //  ERROR not implemented  [subject 1]
-    //  ERROR not implemented  [subject z
+    //    ERROR not implemented expected either point, box or polygon [name=A general description ]
+    //    ERROR not implemented expected either point, box or polygon [scheme=null x=1 y=nullscheme=degrees north=79.5 east=23.0 south=76.7 west=10.0]
+    //    ERROR not implemented expected either point, box or polygon [scheme=degrees north=79.5 east=23.0 south=76.7 west=10.0(exterior=null, interior=null) ]
+    //    ERROR not implemented expected either point, box or polygon [scheme=null x=1 y=null(exterior=null, interior=null) ]
     val triedDDM = DDM(emd, Seq("D35400"), abrMapping)
     triedDDM.map(normalized) shouldBe Success(normalized(
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>


### PR DESCRIPTION
Fixes DD-638

#### When applied it will...
* Ignore empty eas:place in spatial
* Add a specific test


#### Where should the reviewer @DANS-KNAW/easy start?
