### PR TITLE
DD-639: Add depositor-info/agreements.xml to second bag

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -154,6 +154,10 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       .inputStream
       .map(addMetadataStreamTo(bag2, fileName))
       .get
+    def copyFromDepositorInfo(fileName: String) = (metadataOfBag1 / "depositor-info" / fileName)
+      .inputStream
+      .map(addMetadataStreamTo(bag2, "depositor-info/"+fileName))
+      .get
 
     for {
       _ <- copy("emd.xml")
@@ -162,6 +166,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ <- metadataOfBag1.list.toList
         .filter(_.name.toLowerCase.contains("license"))
         .traverse(file => copy(file.name))
+      _ <- copyFromDepositorInfo("agreements.xml")
       fileItems <- fileInfos
         .traverse(addPayloadFileTo(bag2, isOriginalVersioned = true))
       _ <- checkNotImplementedFileMetadata(fileItems, logger)

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -154,10 +154,6 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       .inputStream
       .map(addMetadataStreamTo(bag2, fileName))
       .get
-    def copyFromDepositorInfo(fileName: String) = (metadataOfBag1 / "depositor-info" / fileName)
-      .inputStream
-      .map(addMetadataStreamTo(bag2, "depositor-info/"+fileName))
-      .get
 
     for {
       _ <- copy("emd.xml")
@@ -166,7 +162,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ <- metadataOfBag1.list.toList
         .filter(_.name.toLowerCase.contains("license"))
         .traverse(file => copy(file.name))
-      _ <- copyFromDepositorInfo("agreements.xml")
+      _ <- copy("depositor-info/agreements.xml")
       fileItems <- fileInfos
         .traverse(addPayloadFileTo(bag2, isOriginalVersioned = true))
       _ <- checkNotImplementedFileMetadata(fileItems, logger)

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -108,6 +108,12 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
       (XML.loadFile((bag / "metadata" / "files.xml").toJava) \\ "file").theSeq.size shouldBe
         nrOfFiles
     }
+
+    //post condition: both bags should have the depositor-info/agreements.xml
+    testDir.listRecursively.withFilter(_.name == "data").map(_.parent).foreach { bag =>
+      val agreementsXml = bag / "metadata" / "depositor-info" / "agreements.xml"
+      agreementsXml.exists shouldBe true
+    }
   }
 
   it should "produce just one bag referring to payload in EASY from the same dataset" in {


### PR DESCRIPTION
Fixes DD-639

#### When applied it will...
* Add depositor-info/agreements.xml to second bag


#### Where should the reviewer @DANS-KNAW/easy start?


