### PR TITLE
DD-655 pick one file in case of duplicates

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -210,10 +210,10 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       amd <- getAmd(foXml)
       audiences <- emd.getEmdAudience.getDisciplines.asScala
         .map(id => getAudience(id.getValue)).collectResults
-      fedoraIDs <- if (options.noPayload) Success(Seq.empty)
-                   else fsRdb.getSubordinates(datasetId)
+      fedoraFileIDs <- if (options.noPayload) Success(Seq.empty)
+                       else fsRdb.getSubordinates(datasetId)
       isOriginalVersioned = options.transformationType == ORIGINAL_VERSIONED
-      allFileInfos <- FileInfo(fedoraIDs.filter(_.startsWith("easy-file:")).toList, fedoraProvider).map(_.toList)
+      allFileInfos <- FileInfo(fedoraFileIDs, fedoraProvider).map(_.toList)
       selectedForSecondBag = allFileInfos.selectForSecondBag(isOriginalVersioned, options.noPayload)
       selectedForFirstBag <- allFileInfos.selectForFirstBag(emdXml, selectedForSecondBag.nonEmpty, options.europeana, options.noPayload)
       tooManyFiles = !hasTooManyFiles(selectedForSecondBag, selectedForFirstBag)
@@ -223,7 +223,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ = trace("creating DDM from EMD")
       ddm <- DDM(emd, audiences, configuration.abrMapping, payloadInEasy(tooManyFiles))
       _ = trace("created DDM from EMD")
-      maybeFilterViolations <- options.datasetFilter.violations(emd, ddm, amd, fedoraIDs, allFileInfos, configuration.exportStates)
+      maybeFilterViolations <- options.datasetFilter.violations(emd, ddm, amd, allFileInfos, configuration.exportStates)
       _ = if (options.strict) maybeFilterViolations.foreach(msg => throw InvalidTransformationException(msg))
       _ = (ddm \\ "implemented").filter(_.prefix == "not").foreach(n => throw InvalidTransformationException(n.toString()))
       // so far for collecting data, now we start writing

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -212,12 +212,14 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
         .map(id => getAudience(id.getValue)).collectResults
       fedoraIDs <- if (options.noPayload) Success(Seq.empty)
                    else fsRdb.getSubordinates(datasetId)
-      allFileInfos <- FileInfo(fedoraIDs.filter(_.startsWith("easy-file:")).toList, fedoraProvider).map(_.toList)
       isOriginalVersioned = options.transformationType == ORIGINAL_VERSIONED
+      allFileInfos <- FileInfo(fedoraIDs.filter(_.startsWith("easy-file:")).toList, fedoraProvider).map(_.toList)
       selectedForSecondBag = allFileInfos.selectForSecondBag(isOriginalVersioned, options.noPayload)
       selectedForFirstBag <- allFileInfos.selectForFirstBag(emdXml, selectedForSecondBag.nonEmpty, options.europeana, options.noPayload)
       tooManyFiles = !hasTooManyFiles(selectedForSecondBag, selectedForFirstBag)
       _ = trace(tooManyFiles, selectedForFirstBag.size, selectedForSecondBag.size, options.noPayload, options.cutoff)
+      (forFirstBag, forSecondBag) <- if (!tooManyFiles) checkDuplicates(selectedForFirstBag, selectedForSecondBag, isOriginalVersioned)
+                                     else Success((Seq.empty, Seq.empty))
       _ = trace("creating DDM from EMD")
       ddm <- DDM(emd, audiences, configuration.abrMapping, payloadInEasy(tooManyFiles))
       _ = trace("created DDM from EMD")
@@ -249,9 +251,6 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ <- getFilesXml(foXml)
         .map(addXmlMetadataTo(bag, "original/files.xml"))
         .getOrElse(Success(()))
-      // TODO one more action to move up before creating the bag. It would break a test and we can live with it for now.
-      (forFirstBag, forSecondBag) <- if (!tooManyFiles) checkDuplicates(selectedForFirstBag, selectedForSecondBag, isOriginalVersioned)
-                                     else Success((Seq.empty, Seq.empty))
       fileItemsForFirstBag <- forFirstBag.toList.traverse(addPayloadFileTo(bag, isOriginalVersioned))
       _ <- checkNotImplementedFileMetadata(fileItemsForFirstBag, logger)
       _ <- addXmlMetadataTo(bag, "files.xml")(filesXml(fileItemsForFirstBag))

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -159,7 +159,7 @@ object FileInfo extends DebugEnhancedLogging {
       val conflicts = grouped.filter(_.size > 1)
       if (conflicts.isEmpty) Success(grouped.flatten)
       else Failure(InvalidTransformationException(
-        s"Files with same bag path but different shas: " + conflicts.flatten.mkString(", ")
+        s"Files with same bag path but different SHAs: " + conflicts.flatten.mkString(", ")
       ))
     }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -146,14 +146,14 @@ object FileInfo extends DebugEnhancedLogging {
       else if (filesWithSameBagPath.map(_.contentDigest).distinct.size != 1)
              filesWithSameBagPath // conflicting shas, keep both, they will be reported by caller
            else {
-             val newest = Seq(filesWithSameBagPath.maxBy(_.fedoraFileId))
-             val msg = s"Picked $newest from " + filesWithSameBagPath.mkString(", ")
+             val newest = filesWithSameBagPath.maxBy(_.fedoraFileId)
+             val msg = s"Picked ${newest.fedoraFileId} from " + filesWithSameBagPath.mkString(", ")
              if (filesWithSameBagPath
                .map(f => (f.accessibleTo, f.visibleTo, f.additionalMetadata))
                .distinct.nonEmpty
              ) logger.warn(msg)
              else logger.info(msg)
-             newest
+             Seq(newest)
            }
     }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -163,13 +163,13 @@ object FileInfo extends DebugEnhancedLogging {
       ))
     }
 
-    for {
-      // TODO conflicting duplicate paths for second bag are not report if first one has too
-      forFirst <- groupByBagPath(selectedForFirstBag)
-      forSecond <- groupByBagPath(selectedForSecondBag)
-    } yield if (forFirst.map(versionedInfo) == forSecond.map(versionedInfo))
-              (forSecond, Seq.empty)
-            else (forFirst, forSecond)
+    (groupByBagPath(selectedForFirstBag), groupByBagPath(selectedForSecondBag)) match {
+      case (Failure(e1), Failure(e2)) => Failure(InvalidTransformationException (s"${e1.getMessage} ${e2.getMessage}"))
+      case (Failure(e), _) => Failure(e)
+      case (_, Failure(e)) => Failure(e)
+      case (Success(for1), Success(for2)) if for1.map(versionedInfo) == for2.map(versionedInfo) => Success(for2,Seq.empty)
+      case (Success(for1), Success(for2)) => Success(for1,for2)
+    }
   }
 
   private def versionedInfo(fileInfo: FileInfo): FileInfo = fileInfo.copy(

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -152,7 +152,7 @@ object FileInfo extends DebugEnhancedLogging {
                .map(f => (f.accessibleTo, f.visibleTo, f.additionalMetadata))
                .distinct.nonEmpty
              ) logger.warn(msg)
-             else logger.info(msg)
+             else logger.debug(msg)
              Seq(newest)
            }
     }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -146,14 +146,15 @@ object FileInfo extends DebugEnhancedLogging {
       else if (filesWithSameBagPath.map(_.contentDigest).distinct.size != 1)
              filesWithSameBagPath // conflicting shas, keep both, they will be reported by caller
            else {
-             val newest = filesWithSameBagPath.maxBy(_.fedoraFileId)
-             val msg = s"Picked ${newest.fedoraFileId} from " + filesWithSameBagPath.mkString(", ")
+             // pick the the most recent file based on the id
+             val latest = filesWithSameBagPath.maxBy(_.fedoraFileId)
+             val msg = s"Picked ${ latest.fedoraFileId } from " + filesWithSameBagPath.mkString(", ")
              if (filesWithSameBagPath
-               .map(f => (f.accessibleTo, f.visibleTo, f.additionalMetadata))
-               .distinct.nonEmpty
+               .map(f => (f.accessibleTo, f.visibleTo, f.additionalMetadata, f.wasDerivedFrom, f.originalPath))
+               .size > 1 // the files have the same sha but different metadata
              ) logger.warn(msg)
              else logger.debug(msg)
-             Seq(newest)
+             Seq(latest)
            }
     }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/DatasetFilter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/DatasetFilter.scala
@@ -31,7 +31,7 @@ trait DatasetFilter extends DebugEnhancedLogging {
   val allowOriginalAndOthers: Boolean = false
   private val invalidStateKey = "5: invalid state"
 
-  def violations(emd: EasyMetadataImpl, ddm: Node, amd: Node, fedoraIDs: Seq[String] = Seq.empty, fileInfos: List[FileInfo] = List.empty, exportStates: List[String]): Try[Option[String]] = {
+  def violations(emd: EasyMetadataImpl, ddm: Node, amd: Node, fileInfos: List[FileInfo] = List.empty, exportStates: List[String]): Try[Option[String]] = {
     val maybeDoi = Option(emd.getEmdIdentifier.getDansManagedDoi)
     val mixOfOriginalAndOthers = allowOriginalAndOthers || !fileInfos.hasOriginalAndOthers
     val triedMaybeInTargetResponse: Try[Option[String]] = maybeDoi

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -281,7 +281,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
         "easy-discipline:6" -> audienceFoXML("easy-discipline:6", "D35400"),
         "easy-file:1" -> fileFoXml(id = 1, location = "original/a", name = "x.txt", digest = digests("acabadabra")),
         "easy-file:2" -> fileFoXml(id = 2, location = "a", name = "x.txt", digest = digests("acabadabra")),
-        "easy-file:3" -> fileFoXml(id = 3, name = "y.txt", digest = digests("acabadabra")),
+        "easy-file:3" -> fileFoXml(id = 3, name = "y.txt", digest = digests("barbapappa")),
         "easy-file:4" -> fileFoXml(id = 4, location = "a", name = "z.txt", digest = digests("lalala")),
       ).foreach { case (id, xml) =>
         (fedoraProvider.loadFoXml(_: String)) expects id once() returning Success(xml)
@@ -289,7 +289,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
       Map(
         "easy-file:1" -> ("acabadabra", 1),
         "easy-file:2" -> ("acabadabra",1),
-        "easy-file:3" -> ("acabadabra",2), // this one in both bags, the others each in one of the bags
+        "easy-file:3" -> ("barbapappa",2), // this one in both bags, the others each in one of the bags
         "easy-file:4" -> ("lalala", 1),
       ).foreach { case (id, (content, times)) =>
         (fedoraProvider.disseminateDatastream(_: String, _: String)) expects(id, "EASY_FILE"
@@ -311,7 +311,41 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     // post condition
     sw.toString.split("\n").last should fullyMatch regex
-      s"easy-dataset:13,.*,.*,10.17026/mocked-Iiib-z9p-4ywa,user001,original-versioned,OK"
+      "easy-dataset:13,.*,.*,10.17026/mocked-Iiib-z9p-4ywa,user001,original-versioned,OK"
+  }
+
+  it should "report a SHA conflict on files with identical bag path" in {
+    val app: AppWithMockedServices = new AppWithMockedServices() {
+      Map(
+        "easy-dataset:13" -> XML.loadFile((sampleFoXML / "streaming.xml").toJava),
+        "easy-discipline:6" -> audienceFoXML("easy-discipline:6", "D35400"),
+        "easy-file:1" -> fileFoXml(id = 1, location = "original/a", name = "x.txt", digest = digests("acabadabra")),
+        "easy-file:2" -> fileFoXml(id = 2, location = "a", name = "x.txt", digest = digests("rabarbera")),
+        "easy-file:3" -> fileFoXml(id = 3, name = "y.txt", digest = digests("barbapappa")),
+        "easy-file:4" -> fileFoXml(id = 4, location = "a", name = "z.txt", digest = digests("lalala")),
+      ).foreach { case (id, xml) =>
+        (fedoraProvider.loadFoXml(_: String)) expects id once() returning Success(xml)
+      }
+      (fsRdb.getSubordinates(_: String)) expects "easy-dataset:13" once() returning
+        Success(Seq("easy-file:1", "easy-file:2", "easy-file:3", "easy-file:4"))
+    }
+
+    // end of mocking
+
+    val sw = new StringWriter()
+    app.createOriginalVersionedExport(
+      Iterator("easy-dataset:13"),
+      (testDir / "output").createDirectories(),
+      Options(SimpleDatasetFilter(allowOriginalAndOthers = true), ORIGINAL_VERSIONED),
+      AIP
+    )(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
+
+    // post condition
+    sw.toString.split("\n").last should (
+      fullyMatch regex """easy-dataset:13,.*,,,,-,"FAILED: .*InvalidTransformationException: Files with same bag path but different SHAs: .*"""
+      and include("FileInfo(easy-file:1,original/a/x.txt,x.txt,30.0,text/plain,RESTRICTED_REQUEST,ANONYMOUS,Some(<foxml:contentDigest ")
+      and include("FileInfo(easy-file:2,a/x.txt,x.txt,30.0,text/plain,RESTRICTED_REQUEST,ANONYMOUS,Some(<foxml:contentDigest ")
+      )
   }
 
   "createBag" should "report not strict simple violation" in {

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -319,7 +319,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
       Map(
         "easy-dataset:13" -> XML.loadFile((sampleFoXML / "streaming.xml").toJava),
         "easy-discipline:6" -> audienceFoXML("easy-discipline:6", "D35400"),
-        "easy-file:1" -> fileFoXml(id = 1, location = "original/a", name = "x.txt", digest = digests("acabadabra")),
+        "easy-file:1" -> fileFoXml(id = 2, location = "original/a", name = "x.txt", digest = digests("acabadabra")),
         "easy-file:2" -> fileFoXml(id = 2, location = "a", name = "x.txt", digest = digests("rabarbera")),
         "easy-file:3" -> fileFoXml(id = 3, name = "y.txt", digest = digests("barbapappa")),
         "easy-file:4" -> fileFoXml(id = 4, location = "a", name = "z.txt", digest = digests("lalala")),

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -233,7 +233,6 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
       """easyDatasetId,uuid1,uuid2,doi,depositor,transformationType,comment
         |easy-dataset:17,.+,,10.17026/test-Iiib-z9p-4ywa,user001,original-versioned without second bag,OK
         |""".stripMargin
-    val Array(_,line) = sw.toString.split("\n")
     testDir.listRecursively.filter(_.name == "dataset.xml").toSeq.head.contentAsString should
       include ("""<dc:title xml:lang="nld">as
                  |                        with another line</dc:title>""".stripMargin)
@@ -276,7 +275,6 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
   it should "report a duplicate file" in {
     val app: AppWithMockedServices = new AppWithMockedServices() {
-      expectAUser()
       Map(
         "easy-dataset:13" -> XML.loadFile((sampleFoXML / "streaming.xml").toJava),
         "easy-discipline:6" -> audienceFoXML("easy-discipline:6", "D35400"),

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DatasetFilterSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DatasetFilterSpec.scala
@@ -47,7 +47,7 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     val emd = parseEmdContent(Seq(emdTitle, emdDoi, emdRights))
 
     themaChecker(loggerExpectsWarnings = Seq.empty)
-      .violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq(),List.empty, exportStates) shouldBe
+          .violations(emd, emd2ddm(emd), amd("PUBLISHED"), List.empty, exportStates) shouldBe
       Success(None)
   }
 
@@ -56,8 +56,8 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     val emd = parseEmdContent(Seq(emdTitle, emdDoi, emdRights))
 
     themaChecker(loggerExpectsWarnings = Seq(
-      "violated 3: invalid title some collection",
-    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq(),List.empty, exportStates) shouldBe
+          "violated 3: invalid title some collection",
+        )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), List.empty, exportStates) shouldBe
       Success(Some("Violates 3: invalid title"))
   }
 
@@ -70,8 +70,8 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     ).map(p => new FileInfo("easy-file:2", Paths.get(p), "x.txt", 2, "text/plain", "ANONYMOUS", "ANONYMOUS", None, None, None, Paths.get(p)))
 
     simpleChecker(loggerExpectsWarnings = Seq(
-      "violated 8: original and other files should not occur both",
-    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), fedoraIDs = Seq(), fileInfos, exportStates) shouldBe
+          "violated 8: original and other files should not occur both",
+        )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), fileInfos, exportStates) shouldBe
       Success(Some("Violates 8: original and other files"))
   }
 
@@ -84,25 +84,25 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
       "x.txt",
     ).map(p => new FileInfo("easy-file:2", Paths.get(p), "x.txt", 2, "text/plain", "ANONYMOUS", "ANONYMOUS", None, None, None, Paths.get(p)))
 
-    FedoraVersionedFilter().violations(emd, ddm, amd("PUBLISHED"), fedoraIDs = Seq(), fileInfos, exportStates) shouldBe
+    FedoraVersionedFilter().violations(emd, ddm, amd("PUBLISHED"), fileInfos, exportStates) shouldBe
       Success(None)
     SimpleDatasetFilter(allowOriginalAndOthers = true)
-      .violations(emd, ddm, amd("PUBLISHED"), fedoraIDs = Seq(), fileInfos, exportStates) shouldBe
+          .violations(emd, ddm, amd("PUBLISHED"), fileInfos, exportStates) shouldBe
       Success(None)
   }
 
   "SimpleChecker.simpleViolations" should "succeed" in {
     val emdTitle = <emd:title><dc:title xml:lang="nld">no theme</dc:title></emd:title>
     val emd = parseEmdContent(Seq(emdTitle, emdDoi, emdRights))
-    simpleChecker(loggerExpectsWarnings = Seq(), mockBagIndexRespondsWith(body = "", code = 404)).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty, List.empty, exportStates) shouldBe
+    simpleChecker(loggerExpectsWarnings = Seq(), mockBagIndexRespondsWith(body = "", code = 404)).violations(emd, emd2ddm(emd), amd("PUBLISHED"), List.empty, exportStates) shouldBe
       Success(None)
   }
 
   it should "report missing DOI" in {
     val emd = parseEmdContent(emdRights)
     simpleChecker(loggerExpectsWarnings = Seq(
-      "violated 1: DANS DOI not found",
-    ), bagIndex = null).violations(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty,List.empty, exportStates) shouldBe
+          "violated 1: DANS DOI not found",
+        ), bagIndex = null).violations(emd, emd2ddm(emd), amd("SUBMITTED"), List.empty, exportStates) shouldBe
       Success(Some("Violates 1: DANS DOI"))
   }
 
@@ -111,8 +111,8 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     val emd = parseEmdContent(Seq(emdTitle, emdDoi))
 
     simpleChecker(loggerExpectsWarnings = Seq(
-      "violated 3: invalid title thematische collectie",
-    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq(),List.empty, exportStates) shouldBe
+          "violated 3: invalid title thematische collectie",
+        )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), List.empty, exportStates) shouldBe
       Success(Some("Violates 3: invalid title"))
   }
 
@@ -120,8 +120,8 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     val emd = parseEmdContent(emdDoi)
     val exportStates = List("PUBLISHED")
     simpleChecker(loggerExpectsWarnings = Seq(
-      "violated 5: invalid state SUBMITTED",
-    )).violations(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty,List.empty, exportStates) shouldBe
+          "violated 5: invalid state SUBMITTED",
+        )).violations(emd, emd2ddm(emd), amd("SUBMITTED"), List.empty, exportStates) shouldBe
       Success(Some("Violates 5: invalid state (SUBMITTED)"))
   }
 
@@ -140,10 +140,10 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
       emdRights
     ))
     simpleChecker(loggerExpectsWarnings = Seq(
-      "violated 6: DANS relations <dct:isVersionOf>https://doi.org/10.17026/test-123-456</dct:isVersionOf>",
-      "violated 6: DANS relations <dct:isVersionOf>http://www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-2ajw-cq</dct:isVersionOf>",
-      """violated 6: DANS relations <ddm:replaces scheme="id-type:URN" href="http://persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-aka-hff">Prehistorische bewoning op het World Forum gebied - Den Haag (replaces)</ddm:replaces>""",
-    )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty,List.empty, exportStates) shouldBe
+          "violated 6: DANS relations <dct:isVersionOf>https://doi.org/10.17026/test-123-456</dct:isVersionOf>",
+          "violated 6: DANS relations <dct:isVersionOf>http://www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-2ajw-cq</dct:isVersionOf>",
+          """violated 6: DANS relations <ddm:replaces scheme="id-type:URN" href="http://persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-aka-hff">Prehistorische bewoning op het World Forum gebied - Den Haag (replaces)</ddm:replaces>""",
+        )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), List.empty, exportStates) shouldBe
       Success(Some("Violates 6: DANS relations"))
   }
 
@@ -151,9 +151,9 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     val emd = parseEmdContent(Seq(emdDoi, emdRights))
     val result = "<bag-info><bag-id>blabla</bag-id><doi>10.80270/test-zwu-cxjx</doi></bag-info>"
     simpleChecker(
-      loggerExpectsWarnings = Seq(s"violated 7: is in the vault $result"),
-      mockBagIndexRespondsWith(body = s"<result>$result</result>", code = 200),
-    ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty,List.empty, exportStates) shouldBe
+          loggerExpectsWarnings = Seq(s"violated 7: is in the vault $result"),
+          mockBagIndexRespondsWith(body = s"<result>$result</result>", code = 200),
+        ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), List.empty, exportStates) shouldBe
       Success(Some("Violates 7: is in the vault"))
   }
 


### PR DESCRIPTION
Fixes DD-665 pick one file in case of duplicates

#### When applied it will...
* [x] pick the file with the largest ID. 
* [x] Log both Ids if metadata is different.
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
