### PR TITLE
DD-601: original_file AND archival_name: no longer an error

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
@@ -16,13 +16,14 @@
 package nl.knaw.dans.easy.fedoratobag
 
 import com.typesafe.scalalogging.Logger
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import java.nio.file.Path
 import java.util.Locale
 import scala.util.{ Failure, Success, Try }
 import scala.xml._
 
-object FileItem {
+object FileItem extends DebugEnhancedLogging {
 
   private val baseNS = "http://easy.dans.knaw.nl/schemas/bag/metadata"
 
@@ -82,12 +83,12 @@ object FileItem {
     val hasOriginalFile = (additionalContent \ "original_file").nonEmpty // EASY-II
     additionalContent.nonEmptyChildren.map {
       case Elem(_, label, attributes, _, Text(value)) if attributes.nonEmpty => <notImplemented>{ s"$label(attributes: $attributes): $value" }</notImplemented>
-      case Elem(_, "file_name", _, _, _) if hasArchivalName && hasOriginalFile => <notImplemented>original_file AND archival_name</notImplemented>
 
       case Elem(_, "original_file", _, _, Text(value)) => <dct:isFormatOf>{ value }</dct:isFormatOf>
-      case Elem(_, "file_name", _, _, Text(value)) if hasOriginalFile => <dct:title>{ value }</dct:title>
 
+      case Elem(_, "file_name", _, _, Text(value)) if hasOriginalFile => <dct:title>{ value }</dct:title>
       case Elem(_, "file_name", _, _, Text(value)) if hasArchivalName => <dct:isFormatOf>{ value }</dct:isFormatOf>
+
       case Elem(_, "archival_name", _, _, Text(value)) => <dct:title>{ value }</dct:title>
 
       case Elem(_, "case_quantity", _, _, Text(value)) if value.trim == "1" => Text("") // RAAP mis-interpretation

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
@@ -385,7 +385,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
     triedFileItem.flatMap(validateItem) shouldBe Success(())
   }
 
-  "checkNotImplemented" should "report an original_file combined with archival_name" in {
+  "checkNotImplemented" should "no longer report an original_file combined with archival_name" in {
     val fileMetadata = {
       <name>A</name>
       <path>B/A</path>
@@ -415,7 +415,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
           <dct:format>C</dct:format>
           <dct:extent>0.0MB</dct:extent>
           <afm:keyvaluepair><afm:key>blabla</afm:key><afm:value>K</afm:value></afm:keyvaluepair>
-          <notImplemented>original_file AND archival_name</notImplemented>
+          <dct:title>G</dct:title>
           <dct:isFormatOf>I</dct:isFormatOf>
           <dct:title>j</dct:title>
           <accessibleToRights>F</accessibleToRights>
@@ -423,14 +423,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
       </file>
     ))
     val mockLogger = mock[UnderlyingLogger]
-    Seq(
-      "easy-file:35 (data/B/A) NOT IMPLEMENTED: original_file AND archival_name",
-    ).foreach(s => (mockLogger.warn(_: String)) expects s once())
-    (() => mockLogger.isWarnEnabled()) expects() anyNumberOfTimes() returning true
-
-    FileItem.checkNotImplementedFileMetadata(List(triedFileItem.get), Logger(mockLogger)) should matchPattern {
-      case Failure(e) if e.getMessage == "1 file(s) with not implemented additional file metadata: List(original_file AND archival_name)" =>
-    }
+    FileItem.checkNotImplementedFileMetadata(List(triedFileItem.get), Logger(mockLogger)) shouldBe a[Success[_]]
   }
 
   it should "report items once" in {


### PR DESCRIPTION
Fixes DD-601: original_file AND archival_name: no longer an error

#### When applied it will...
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
