### PR TITLE
DD-636: Allow datasets with NoPayload

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -192,11 +192,24 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       }
     }
 
+    def getInfoFirstBag(allFileInfos: List[FileInfo], emd: Node, hasSecondBag: Boolean): Try[List[FileInfo]] = {
+      for {
+        fileInfo <- allFileInfos.selectForFirstBag(emd, hasSecondBag, options.europeana, options.noPayload)
+        result = if (fileInfo.isEmpty && options.strict) throw NoPayloadFilesException()
+        else {
+          if (fileInfo.isEmpty) logger.warn(s"No payload files in dataset $datasetId")
+          fileInfo
+        }
+      } yield result
+    }
+
+
     def payloadInEasy(tooManyFiles: Boolean) = {
       if (tooManyFiles)
         <dct:description xml:lang="en">{ s"<![CDATA[<b>Files not yet migrated to Data Station. Files for this dataset can be found at ${makelink(datasetId)}.</b>]]>" }</dct:description>
       else Text("")
     }
+
     def makelink(datasetId: DatasetId): Node = {
      <a href={ s"https://easy.dans.knaw.nl/ui/datasets/id/$datasetId/tab/2" }>{ s"https://easy.dans.knaw.nl/ui/datasets/id/$datasetId" }</a>
     }
@@ -215,7 +228,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       allFileInfos <- FileInfo(fedoraIDs.filter(_.startsWith("easy-file:")).toList, fedoraProvider).map(_.toList)
       isOriginalVersioned = options.transformationType == ORIGINAL_VERSIONED
       selectedForSecondBag = allFileInfos.selectForSecondBag(isOriginalVersioned, options.noPayload)
-      selectedForFirstBag <- allFileInfos.selectForFirstBag(emdXml, selectedForSecondBag.nonEmpty, options.europeana, options.noPayload)
+      selectedForFirstBag <- getInfoFirstBag(allFileInfos, emdXml, selectedForSecondBag.nonEmpty)
       tooManyFiles = !hasTooManyFiles(selectedForSecondBag, selectedForFirstBag)
       _ = trace(tooManyFiles, selectedForFirstBag.size, selectedForSecondBag.size, options.noPayload, options.cutoff)
       _ = trace("creating DDM from EMD")

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -196,12 +196,11 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
     def getInfoFirstBag(allFileInfos: List[FileInfo], emd: Node, hasSecondBag: Boolean): Try[List[FileInfo]] = {
       for {
         fileInfo <- allFileInfos.selectForFirstBag(emd, hasSecondBag, options.europeana, options.noPayload)
-        result = if (fileInfo.isEmpty && options.strict) throw NoPayloadFilesException()
-        else {
-          if (fileInfo.isEmpty) logger.warn(s"No payload files in dataset $datasetId")
-          fileInfo
+        _ = if (fileInfo.isEmpty && !options.noPayload) {
+          if (options.strict) throw NoPayloadFilesException()
+          else logger.warn(s"No payload files in dataset $datasetId")
         }
-      } yield result
+      } yield fileInfo
     }
 
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -193,14 +193,13 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       }
     }
 
-    def getInfoFirstBag(allFileInfos: List[FileInfo], emd: Node, hasSecondBag: Boolean): Try[List[FileInfo]] = {
-      for {
-        fileInfo <- allFileInfos.selectForFirstBag(emd, hasSecondBag, options.europeana, options.noPayload)
-        _ = if (fileInfo.isEmpty && !options.noPayload) {
-          if (options.strict) throw NoPayloadFilesException()
-          else logger.warn(s"No payload files in dataset $datasetId")
-        }
-      } yield fileInfo
+    def getInfoFirstBag(allFileInfos: List[FileInfo], emd: Node, hasSecondBag: Boolean): Try[List[FileInfo]] = Try {
+      val fileInfo = allFileInfos.selectForFirstBag(emd, hasSecondBag, options.europeana, options.noPayload)
+      if (fileInfo.isEmpty && !options.noPayload) {
+        if (options.strict) throw NoPayloadFilesException()
+        else logger.warn(s"No payload files in dataset $datasetId")
+      }
+      fileInfo
     }
 
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/package.scala
@@ -36,7 +36,7 @@ package object filter {
       fileInfos.exists(_.isOriginal) && fileInfos.exists(!_.isOriginal)
     }
 
-    def selectForFirstBag(emd: Node, hasSecondBag: Boolean, europeana: Boolean, noPayload: Boolean = false): Try[List[FileInfo]] = Try {
+    def selectForFirstBag(emd: Node, hasSecondBag: Boolean, europeana: Boolean, noPayload: Boolean = false): List[FileInfo] = {
 
       def largest(preferred: FileType, alternative: FileType): List[FileInfo] = {
         val infosByType = fileInfos

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileInfosSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileInfosSpec.scala
@@ -34,7 +34,7 @@ class FileInfosSpec extends TestSupportFixture with FileFoXmlSupport with MockFa
     val for2nd = fileInfos.selectForSecondBag(isOriginalVersioned = true)
     val for1st = fileInfos.selectForFirstBag(<emd/>, for2nd.nonEmpty, europeana = false)
     for2nd shouldBe fileInfos
-    for1st shouldBe Success(fileInfos.slice(0, 1))
+    for1st shouldBe fileInfos.slice(0, 1)
   }
   it should "return one file for each bag" in {
     val fileInfos = List(
@@ -44,7 +44,7 @@ class FileInfosSpec extends TestSupportFixture with FileFoXmlSupport with MockFa
     val for2nd = fileInfos.selectForSecondBag(isOriginalVersioned = true)
     val for1st = fileInfos.selectForFirstBag(<emd/>, for2nd.nonEmpty, europeana = false)
     for2nd shouldBe fileInfos.slice(1, 2)
-    for1st shouldBe Success(fileInfos.slice(0, 1))
+    for1st shouldBe fileInfos.slice(0, 1)
     // identical files are filtered
   }
   it should "return files for one bag" in {
@@ -55,7 +55,7 @@ class FileInfosSpec extends TestSupportFixture with FileFoXmlSupport with MockFa
     val for2nd = fileInfos.selectForSecondBag(isOriginalVersioned = true)
     val for1st = fileInfos.selectForFirstBag(<emd/>, for2nd.nonEmpty, europeana = false)
     for2nd shouldBe empty
-    for1st shouldBe Success(fileInfos)
+    for1st shouldBe fileInfos
   }
   it should "return no files" in {
     val fileInfos = List(
@@ -67,7 +67,7 @@ class FileInfosSpec extends TestSupportFixture with FileFoXmlSupport with MockFa
     val for2nd = fileInfos.selectForSecondBag(isOriginalVersioned = true, noPayload = true)
     val for1st = fileInfos.selectForFirstBag(<emd/>, for2nd.nonEmpty, europeana = true, noPayload = true)
     for2nd shouldBe empty
-    for1st shouldBe Success(Seq.empty)
+    for1st shouldBe Seq.empty
   }
   "FileInfo" should "replace non allowed characters in name and filepath with '_'" in {
     val foxml = fileFoXml(


### PR DESCRIPTION
Fixes DD-636

#### When applied it will...
* throw `NoPayloadFilesException` only when in `strict mode`, otherwise only warning


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
