### PR TITLE
DD-682: add seq nr to fedora versioned bags

### DIFF
--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -56,8 +56,8 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     }
 
     // make almost private method available for tests
-    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, maybeFirstBagVersion: Option[BagVersion] = None): Try[DatasetInfo] =
-      super.createBag(datasetId, bagDir, options)
+    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, maybeFirstBagVersion: Option[BagVersion] = None, bagSeqNr: Int = 0): Try[DatasetInfo] =
+      super.createBag(datasetId, bagDir, options, maybeFirstBagVersion, bagSeqNr)
   }
 
   "createExport" should "produce two bags" in {
@@ -397,7 +397,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
-    app.createBag("easy-dataset:17", bagDir, Options(app.filter)) should matchPattern {
+    app.createBag("easy-dataset:17", bagDir, Options(app.filter), None, 0) should matchPattern {
       case Failure(_: InvalidTransformationException) =>
     }
     (testDir / "bags") shouldNot exist
@@ -424,7 +424,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
-    app.createBag("easy-dataset:13", bagDir, Options(app.filter)) shouldBe
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter), None, 0) shouldBe
       Success(DatasetInfo(None, "10.17026/mocked-Iiib-z9p-4ywa", "urn:nbn:nl:ui:13-blablabla", "user001", Seq.empty, withPayload = true))
 
     // post conditions
@@ -464,7 +464,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    val triedInfo = app.createBag("easy-dataset:13", bagDir, Options(app.filter))
+    val triedInfo = app.createBag("easy-dataset:13", bagDir, Options(app.filter), None, 0)
     triedInfo should matchPattern {
       case Failure(e) if e.getMessage == "easy-file:35 <visibleTo> not found" =>
     }
@@ -494,7 +494,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    val triedRecord = app.createBag("easy-dataset:13", bagDir, Options(app.filter))
+    val triedRecord = app.createBag("easy-dataset:13", bagDir, Options(app.filter), None, 0)
     triedRecord shouldBe a[Success[_]]
     (bagDir / "data").listRecursively.toList.map(_.name) should
       contain theSameElementsAs List("original", "c.txt", "b.txt", "a.txt")
@@ -520,7 +520,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    val triedRecord = app.createBag("easy-dataset:13", bagDir, Options(app.filter).copy(cutoff = 1))
+    val triedRecord = app.createBag("easy-dataset:13", bagDir, Options(app.filter).copy(cutoff = 1), None, 0)
     triedRecord shouldBe a[Success[_]]
     (bagDir / "data").list shouldBe empty
     (bagDir / "metadata" / "dataset.xml").contentAsString should include(
@@ -549,7 +549,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    val triedRecord = app.createBag("easy-dataset:13", bagDir, Options(app.filter))
+    val triedRecord = app.createBag("easy-dataset:13", bagDir, Options(app.filter), None, 0)
     triedRecord should matchPattern {
       case Failure(e: Exception) if e.getMessage.matches(
         "Different checksums in fedora Some(.*) and exported bag Some(.*) for .*/data/original/a.txt"
@@ -574,7 +574,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     // end of mocking
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    app.createBag("easy-dataset:13", bagDir, Options(app.filter)) shouldBe
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter), None, 0) shouldBe
       Failure(InvalidTransformationException("<not:implemented>invalid box: SpatialBox(Some(RD),None,None,None,None)</not:implemented>"))
   }
 
@@ -601,7 +601,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe a[Success[_]]
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true), None, 0) shouldBe a[Success[_]]
     (bagDir / "data").listRecursively.toList.map(_.name) should
       contain theSameElementsAs List("original", "c.png")
   }
@@ -629,7 +629,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe a[Success[_]]
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true), None, 0) shouldBe a[Success[_]]
     (bagDir / "data").listRecursively.toList.map(_.name) should
       contain theSameElementsAs List("original", "c.pdf")
   }
@@ -659,7 +659,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    app.createBag("easy-dataset:13", bagDir, Options(SimpleDatasetFilter(allowOriginalAndOthers = true), ORIGINAL_VERSIONED))
+    app.createBag("easy-dataset:13", bagDir, Options(SimpleDatasetFilter(allowOriginalAndOthers = true), ORIGINAL_VERSIONED), None, 0)
       .map(_.nextBagFileInfos.map(_.path.toString).sortBy(identity)) shouldBe
       Success(Vector("original/b.pdf", "original/c.pdf", "x/a.txt", "x/e.png"))
 
@@ -684,7 +684,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     // end of mocking
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
-    app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true), None, 0) shouldBe
       Failure(NoPayloadFilesException())
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateSequenceSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/CreateSequenceSpec.scala
@@ -81,7 +81,8 @@ class CreateSequenceSpec extends TestSupportFixture with DelegatingApp with File
     val versionOfUUIDs = bagInfos
       .flatMap(getVersionOfUUID)
       .distinct
-
+    // TODO check that bag-info's with Is-Version-Of have a sequence nr
+    //  and their creation dates are in the right order
     bagInfos should have size 5
     versionOfUUIDs should have size 2
     versionOfUUIDs.map(uuid =>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
@@ -40,18 +40,18 @@ trait DelegatingApp extends MockFactory {
 
     private val delegate = mock[MockEasyFedoraToBagApp]
     createBagExpects.foreach { case (id, result) =>
-      (delegate.createBag(_: DatasetId, _: File, _: Options, _: Option[BagVersion])
-        ) expects(id, *, *, *) returning result
+      (delegate.createBag(_: DatasetId, _: File, _: Options, _: Option[BagVersion], _: Int)
+        ) expects(id, *, *, *, *) returning result
     }
 
-    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, maybeFirstBagVersion: Option[BagVersion] = None): Try[DatasetInfo] = {
+    override def createBag(datasetId: DatasetId, bagDir: File, options: Options, maybeFirstBagVersion: Option[BagVersion] = None, bagSeqNr: Int = 0): Try[DatasetInfo] = {
       // mimic a part of the real method, the tested caller wants to move the bag
       DansV0Bag.empty(bagDir).map { bag =>
-        maybeFirstBagVersion.foreach(_.addTo(bag))
+        maybeFirstBagVersion.foreach(_.addTo(bag).addBagInfo("Seq-nr", bagSeqNr.toString))
         bag.save()
       }.getOrElse(s"mock of createBag failed for $datasetId")
       // mock the outcome of the method
-      delegate.createBag(datasetId, bagDir, options, maybeFirstBagVersion)
+      delegate.createBag(datasetId, bagDir, options, maybeFirstBagVersion, bagSeqNr)
     }
   }
 }


### PR DESCRIPTION
Fixes DD-682: add seq nr to fedora versioned bags

#### When applied it will...
* Add `Seq-nr` to bag-info.txt for fedora-versioned bags
  * [ ] The exact name for this field was not yet specified.
* The first bag of a sequence won't have a sequence nr.
* The next bag starts with sequence nr 2.

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

Run the tests of `CreateSequenceSpec` one by one. After each test: 
* Select in Intellij the folder `target/test`
* search for `Is-version-of`, these will be found in bags under `output` and `staging`, the latter are failed ones
* check the the values for `Seq-nr` in these files

#### Related pull requests on github
* [ ] easy-convert-bag-to-deposit should use the `Seq-nr` value for migration-info requests and remove the line from `bag-info.txt`