### PR TITLE
DD-682: add seq nr to 2nd original versioned bag

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/BagVersion.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/BagVersion.scala
@@ -24,9 +24,12 @@ case class BagVersion(
                        urn: String,
                        packageId: UUID,
                      ) {
-  def addTo(bag: DansV0Bag): DansV0Bag = {
-    bag.withIsVersionOf(packageId)
+  def addTo(bag: DansV0Bag, maybeSeqNr: Option[Int] = None): DansV0Bag = {
+    maybeSeqNr
       // the following keys should match easy-convert-bag-to-deposit BagInfo
+      .map(nr => bag.addBagInfo("Bag-Sequence-Number ", nr.toString))
+      .getOrElse(bag)
+      .withIsVersionOf(packageId)
       .addBagInfo("Base-DOI", doi)
       .addBagInfo("Base-URN", urn)
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -113,7 +113,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
         bag2 <- DansV0Bag.empty(bagDir2)
         _ = bag2.withEasyUserAccount(datasetInfo.depositor).withCreated(DateTime.now())
         _ = BagVersion(datasetInfo.doi, datasetInfo.urn, packageUuid1)
-          .addTo(bag2)
+          .addTo(bag2, Some(2))
         _ <- fillSecondBag(bag2, bagDir1 / "metadata", datasetInfo.nextBagFileInfos.toList)
         _ <- movePackageAtomically(packageDir2, outputDir)
       } yield Some(packageUuid2)

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/DelegatingApp.scala
@@ -47,7 +47,7 @@ trait DelegatingApp extends MockFactory {
     override def createBag(datasetId: DatasetId, bagDir: File, options: Options, maybeFirstBagVersion: Option[BagVersion] = None): Try[DatasetInfo] = {
       // mimic a part of the real method, the tested caller wants to move the bag
       DansV0Bag.empty(bagDir).map { bag =>
-        maybeFirstBagVersion.foreach(_.addTo(bag))
+        maybeFirstBagVersion.foreach(_.addTo(bag, Some(2)))
         bag.save()
       }.getOrElse(s"mock of createBag failed for $datasetId")
       // mock the outcome of the method


### PR DESCRIPTION
Fixes DD-682: add seq nr to 2nd original versioned bag

#### When applied it will...
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* Run AppSpec "createExport" should "produce two bags"
* examine bag-info.txt of both bags

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
