### PR TITLE
DD-945: String.isBlank is not safe between JDK-8/11

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala
@@ -309,7 +309,7 @@ object DDM extends DebugEnhancedLogging {
       case _ => ??? // recover with Try{...}.getOrElse of caller to fail slow
     }.getOrElse {
       if (uri.toString.startsWith("10.17026/")) s"https://doi.org/$uri"
-      else if (uri.toString.isBlank) null
+      else if (uri.toString.trim.isEmpty) null
       else if (uri.toString.startsWith("www.")) "http://" + uri
            else uri.toString
     }


### PR DESCRIPTION
Fixes EASY-

#### When applied it will...
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
