### PR TITLE
DD-987 Extend easy-fedora-to-bag to accept predefined deposit IDs

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/InputFileRecord.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/InputFileRecord.scala
@@ -1,0 +1,3 @@
+package nl.knaw.dans.easy.fedoratobag
+
+class InputFileRecord (easyId: String, uuid1: String, uuid2: String)


### PR DESCRIPTION
Fixes DD-987

#### When applied it will...
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

* Please compile with JDK-8 because of jibx:

      export JAVA_HOME=`/usr/libexec/java_home -v 1.8`

* ...

#### How should this be manually tested?

* [ ] compile (for the sake of jibx for EMDc) with

      export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
* ...

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
