### PR TITLE
NO JIRA ISSUE: rename 

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -161,7 +161,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
         }
     }
 
-    def moreFilesThanCutOff(selectedForSecondBag: List[FileInfo], selectedForFirstBag: List[FileInfo]): Boolean = {
+    def noPayload(selectedForSecondBag: List[FileInfo], selectedForFirstBag: List[FileInfo]): Boolean = {
       if (selectedForFirstBag.size > options.cutoff || selectedForSecondBag.size > options.cutoff) {
         logger.warn(s"too many files ${ selectedForFirstBag.size }, ${ selectedForSecondBag.size }")
         true
@@ -204,7 +204,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       allFileInfos <- FileInfo(fedoraFileIDs, fedoraProvider).map(_.toList)
       selectedForSecondBag = allFileInfos.selectForSecondBag(isOriginalVersioned, options.noPayload)
       selectedForFirstBag <- getInfoFirstBag(allFileInfos, emdXml, selectedForSecondBag.nonEmpty)
-      skipPayload = moreFilesThanCutOff(selectedForSecondBag, selectedForFirstBag)
+      skipPayload = noPayload(selectedForSecondBag, selectedForFirstBag)
       _ = trace(skipPayload, selectedForFirstBag.size, selectedForSecondBag.size, options.noPayload, options.cutoff)
       (forFirstBag, forSecondBag) <- if (!skipPayload) checkDuplicates(selectedForFirstBag, selectedForSecondBag, isOriginalVersioned)
                                      else Success((Seq.empty, Seq.empty))

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -161,13 +161,12 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
         }
     }
 
-    def hasTooManyFiles(selectedForSecondBag: List[FileInfo], selectedForFirstBag: List[FileInfo]) = {
-      if (!(selectedForFirstBag.size > options.cutoff) && !(selectedForSecondBag.size > options.cutoff))
-        !options.noPayload
-      else {
-        logger.warn(s"too many files ${selectedForFirstBag.size}, ${selectedForSecondBag.size}")
-        false
+    def moreFilesThanCutOff(selectedForSecondBag: List[FileInfo], selectedForFirstBag: List[FileInfo]): Boolean = {
+      if (selectedForFirstBag.size > options.cutoff || selectedForSecondBag.size > options.cutoff) {
+        logger.warn(s"too many files ${ selectedForFirstBag.size }, ${ selectedForSecondBag.size }")
+        true
       }
+      else options.noPayload
     }
 
     def getInfoFirstBag(allFileInfos: List[FileInfo], emd: Node, hasSecondBag: Boolean): Try[List[FileInfo]] = Try {
@@ -180,8 +179,8 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
     }
 
 
-    def payloadInEasy(tooManyFiles: Boolean) = {
-      if (tooManyFiles)
+    def payloadInEasy(skipPayload: Boolean) = {
+      if (skipPayload)
         <dct:description xml:lang="en">{ new PCData(s"<b>Files not yet migrated to Data Station. Files for this dataset can be found at ${makelink(datasetId)}.</b>") }</dct:description>
       else Text("")
     }
@@ -205,12 +204,12 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       allFileInfos <- FileInfo(fedoraFileIDs, fedoraProvider).map(_.toList)
       selectedForSecondBag = allFileInfos.selectForSecondBag(isOriginalVersioned, options.noPayload)
       selectedForFirstBag <- getInfoFirstBag(allFileInfos, emdXml, selectedForSecondBag.nonEmpty)
-      tooManyFiles = !hasTooManyFiles(selectedForSecondBag, selectedForFirstBag)
-      _ = trace(tooManyFiles, selectedForFirstBag.size, selectedForSecondBag.size, options.noPayload, options.cutoff)
-      (forFirstBag, forSecondBag) <- if (!tooManyFiles) checkDuplicates(selectedForFirstBag, selectedForSecondBag, isOriginalVersioned)
+      skipPayload = moreFilesThanCutOff(selectedForSecondBag, selectedForFirstBag)
+      _ = trace(skipPayload, selectedForFirstBag.size, selectedForSecondBag.size, options.noPayload, options.cutoff)
+      (forFirstBag, forSecondBag) <- if (!skipPayload) checkDuplicates(selectedForFirstBag, selectedForSecondBag, isOriginalVersioned)
                                      else Success((Seq.empty, Seq.empty))
       _ = trace("creating DDM from EMD")
-      ddm <- DDM(emd, audiences, configuration.abrMapping, payloadInEasy(tooManyFiles))
+      ddm <- DDM(emd, audiences, configuration.abrMapping, payloadInEasy(skipPayload))
       _ = trace("created DDM from EMD")
       maybeFilterViolations <- options.datasetFilter.violations(emd, ddm, amd, allFileInfos, configuration.exportStates)
       _ = if (options.strict) maybeFilterViolations.foreach(msg => throw InvalidTransformationException(msg))
@@ -246,7 +245,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ <- bag.save
       doi = emd.getEmdIdentifier.getDansManagedDoi
       urn = getUrn(datasetId, emd)
-    } yield DatasetInfo(maybeFilterViolations, doi, urn, depositor, forSecondBag, !tooManyFiles)
+    } yield DatasetInfo(maybeFilterViolations, doi, urn, depositor, forSecondBag, !skipPayload)
   }
 
   private def getUrn(datasetId: DatasetId, emd: EasyMetadataImpl) = {


### PR DESCRIPTION
replaces #98

#### When applied it will...
* gets rid of the confusing negative test
* `noPayload` / `skipPayload` avoid collision in the same name space
* more files than the `cutoff` is treated as `noPayload`
* 

#### Where should the reviewer @DANS-KNAW/easy start?

* Please compile with JDK-8 because of jibx:

      export JAVA_HOME=`/usr/libexec/java_home -v 1.8`

* [ ] related to this rename: the messages are not very concise in https://github.com/DANS-KNAW/easy-fedora-to-bag/blob/7cf71628c4d37d258632589c95ee592ac550ce0e/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala#L175-L176
  They suggest the dataset has no payload  while the command line options might have specified to skip the payload, either through a `cutoff` or with `noPayload`.

#### How should this be manually tested?

* [x] compile (for the sake of jibx for EMD) with

      export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
* ...

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
