### PR TITLE
DD-769: nopayload exception changed into a rule violation

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -206,7 +206,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       _ = trace("creating DDM from EMD")
       ddm <- DDM(emd, audiences, configuration.abrMapping, payloadInEasy(skipPayload))
       _ = trace("created DDM from EMD")
-      maybeFilterViolations <- options.datasetFilter.violations(emd, ddm, amd, allFileInfos, configuration.exportStates)
+      maybeFilterViolations <- options.datasetFilter.violations(emd, ddm, amd, selectedForFirstBag, allFileInfos, configuration.exportStates)
       _ = if (options.strict) maybeFilterViolations.foreach(msg => throw InvalidTransformationException(msg))
       _ = (ddm \\ "implemented").filter(_.prefix == "not").foreach(n => throw InvalidTransformationException(n.toString()))
       // so far for collecting data, now we start writing

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -170,12 +170,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
     }
 
     def getInfoFirstBag(allFileInfos: List[FileInfo], emd: Node, hasSecondBag: Boolean): Try[List[FileInfo]] = Try {
-      val fileInfo = allFileInfos.selectForFirstBag(emd, hasSecondBag, options.europeana, options.noPayload)
-      if (fileInfo.isEmpty && !options.noPayload) {
-        if (options.strict) throw NoPayloadFilesException()
-        else logger.warn(s"Running with original-versioned and no payload found in dataset $datasetId")
-      }
-      fileInfo
+      allFileInfos.selectForFirstBag(emd, hasSecondBag, options.europeana, options.noPayload)
     }
 
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/DatasetFilter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/DatasetFilter.scala
@@ -30,7 +30,7 @@ trait DatasetFilter extends DebugEnhancedLogging {
   val allowOriginalAndOthers: Boolean = false
   private val invalidStateKey = "5: invalid state"
 
-  def violations(emd: EasyMetadataImpl, ddm: Node, amd: Node, fileInfos: List[FileInfo] = List.empty, exportStates: List[String]): Try[Option[String]] = {
+  def violations(emd: EasyMetadataImpl, ddm: Node, amd: Node, fileInfosForFirstBag: List[FileInfo] = List.empty, fileInfos: List[FileInfo] = List.empty, exportStates: List[String]): Try[Option[String]] = {
     val maybeDoi = Option(emd.getEmdIdentifier.getDansManagedDoi)
     val mixOfOriginalAndOthers = allowOriginalAndOthers || !fileInfos.hasOriginalAndOthers
     val triedMaybeInTargetResponse: Try[Option[String]] = maybeDoi
@@ -49,6 +49,7 @@ trait DatasetFilter extends DebugEnhancedLogging {
       "8: original and other files" -> (if (mixOfOriginalAndOthers) Seq.empty
                                         else Seq("should not occur both")),
       "9: STREAMING_SURROGATE_RELATION" -> (if (withSurrogate.isEmpty) {Seq.empty} else Seq(withSurrogate)),
+      "10: no payload" -> (if (fileInfosForFirstBag.isEmpty) {Seq("")} else Seq.empty),
     ).filter(_._2.nonEmpty).toMap
 
     violations.foreach { case (rule, violations) =>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -456,7 +456,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
-    app.createBag("easy-dataset:13", bagDir, Options(app.filter, strict=true))  should matchPattern {
+    app.createBag("easy-dataset:13", bagDir, Options(app.filter))  should matchPattern {
       case Failure(_: InvalidTransformationException) =>
     }
     (testDir / "bags") shouldNot exist

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -384,7 +384,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
     app.createBag("easy-dataset:17", bagDir, Options(app.filter, strict = false)) shouldBe
-      Success(DatasetInfo(Some("Violates 10: no payload"),"10.17026/test-Iiib-z9p-4ywa","urn:nbn:nl:ui:13-00-1haq","user001",List(),true))
+      Success(DatasetInfo(Some("Violates 10: no payload"),"10.17026/test-Iiib-z9p-4ywa","urn:nbn:nl:ui:13-00-1haq","user001",List(),withPayload = true))
 
     // post conditions
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -384,7 +384,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
     app.createBag("easy-dataset:17", bagDir, Options(app.filter, strict = false)) shouldBe
-      Success(DatasetInfo(None,"10.17026/test-Iiib-z9p-4ywa","urn:nbn:nl:ui:13-00-1haq","user001",List(),true))
+      Success(DatasetInfo(Some("Violates 10: no payload"),"10.17026/test-Iiib-z9p-4ywa","urn:nbn:nl:ui:13-00-1haq","user001",List(),true))
 
     // post conditions
 
@@ -408,7 +408,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
     app.createBag("easy-dataset:17", bagDir, Options(app.filter)) shouldBe
-      Failure(NoPayloadFilesException())
+      Failure(InvalidTransformationException("Violates 10: no payload"))
 
     // post conditions
 
@@ -435,9 +435,8 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     val uuid = UUID.randomUUID
     val bagDir = testDir / "bags" / uuid.toString
-    app.createBag("easy-dataset:17", bagDir, Options(app.filter)) should matchPattern {
-      case Failure(_: InvalidTransformationException) =>
-    }
+    app.createBag("easy-dataset:17", bagDir, Options(app.filter)) shouldBe
+      Failure(InvalidTransformationException("Violates 1: DANS DOI"))
     (testDir / "bags") shouldNot exist
   }
 
@@ -730,7 +729,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
       contain theSameElementsAs List("c.pdf", "b.pdf", "d.pdf")
   }
 
-  it should "cause NoPayloadFilesException" in {
+  it should "report No Payload" in {
     val app: AppWithMockedServices = new AppWithMockedServices() {
       (fsRdb.getSubordinates(_: String)) expects "easy-dataset:13" once() returning
         Success(Seq("easy-file:1", "easy-file:5"))
@@ -748,6 +747,6 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
 
     val bagDir = testDir / "bags" / UUID.randomUUID.toString
     app.createBag("easy-dataset:13", bagDir, Options(app.filter, europeana = true)) shouldBe
-      Failure(NoPayloadFilesException())
+      Failure(InvalidTransformationException("Violates 9: STREAMING_SURROGATE_RELATION; 10: no payload"))
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/DatasetFilterSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/DatasetFilterSpec.scala
@@ -42,12 +42,14 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
                          >10.17026/test-Iiib-z9p-4ywa</dc:identifier>
                        </emd:identifier>
 
+  private val fileInfo = new FileInfo("", Paths.get("-"),"",0,"","","", None, None,None,Paths.get("-"))
+
   "ThemaChecker.simpleViolations" should "accept thematische collectie" in {
     val emdTitle = <emd:title><dc:title xml:lang="nld">some thematische collectie</dc:title></emd:title>
-    val emd = parseEmdContent(Seq(emdTitle, emdDoi, emdRights))
 
+    val emd = parseEmdContent(Seq(emdTitle, emdDoi, emdRights))
     themaChecker(loggerExpectsWarnings = Seq.empty)
-          .violations(emd, emd2ddm(emd), amd("PUBLISHED"), List.empty, exportStates) shouldBe
+          .violations(emd, emd2ddm(emd), amd("PUBLISHED"), List(fileInfo), List.empty, exportStates) shouldBe
       Success(None)
   }
 
@@ -57,7 +59,7 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
 
     themaChecker(loggerExpectsWarnings = Seq(
           "violated 3: invalid title some collection",
-        )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), List.empty, exportStates) shouldBe
+        )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), List(fileInfo), List.empty, exportStates) shouldBe
       Success(Some("Violates 3: invalid title"))
   }
 
@@ -71,7 +73,7 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
 
     simpleChecker(loggerExpectsWarnings = Seq(
           "violated 8: original and other files should not occur both",
-        )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), fileInfos, exportStates) shouldBe
+        )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), List(fileInfo), fileInfos, exportStates) shouldBe
       Success(Some("Violates 8: original and other files"))
   }
 
@@ -85,14 +87,14 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     ).map(p => new FileInfo("easy-file:2", Paths.get(p), "x.txt", 2, "text/plain", "ANONYMOUS", "ANONYMOUS", None, None, None, Paths.get(p)))
 
     SimpleDatasetFilter(allowOriginalAndOthers = true)
-          .violations(emd, ddm, amd("PUBLISHED"), fileInfos, exportStates) shouldBe
+          .violations(emd, ddm, amd("PUBLISHED"), List(fileInfo), fileInfos, exportStates) shouldBe
       Success(None)
   }
 
   "SimpleChecker.simpleViolations" should "succeed" in {
     val emdTitle = <emd:title><dc:title xml:lang="nld">no theme</dc:title></emd:title>
     val emd = parseEmdContent(Seq(emdTitle, emdDoi, emdRights))
-    simpleChecker(loggerExpectsWarnings = Seq(), mockBagIndexRespondsWith(body = "", code = 404)).violations(emd, emd2ddm(emd), amd("PUBLISHED"), List.empty, exportStates) shouldBe
+    simpleChecker(loggerExpectsWarnings = Seq(), mockBagIndexRespondsWith(body = "", code = 404)).violations(emd, emd2ddm(emd), amd("PUBLISHED"), List(fileInfo), List.empty, exportStates) shouldBe
       Success(None)
   }
 
@@ -100,7 +102,7 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     val emd = parseEmdContent(emdRights)
     simpleChecker(loggerExpectsWarnings = Seq(
           "violated 1: DANS DOI not found",
-        ), bagIndex = null).violations(emd, emd2ddm(emd), amd("SUBMITTED"), List.empty, exportStates) shouldBe
+        ), bagIndex = null).violations(emd, emd2ddm(emd), amd("SUBMITTED"), List(fileInfo), List.empty, exportStates) shouldBe
       Success(Some("Violates 1: DANS DOI"))
   }
 
@@ -110,7 +112,7 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
 
     simpleChecker(loggerExpectsWarnings = Seq(
           "violated 3: invalid title thematische collectie",
-        )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), List.empty, exportStates) shouldBe
+        )).violations(emd, emd2ddm(emd), amd("PUBLISHED"), List(fileInfo), List.empty, exportStates) shouldBe
       Success(Some("Violates 3: invalid title"))
   }
 
@@ -119,7 +121,7 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     val exportStates = List("PUBLISHED")
     simpleChecker(loggerExpectsWarnings = Seq(
           "violated 5: invalid state SUBMITTED",
-        )).violations(emd, emd2ddm(emd), amd("SUBMITTED"), List.empty, exportStates) shouldBe
+        )).violations(emd, emd2ddm(emd), amd("SUBMITTED"), List(fileInfo), List.empty, exportStates) shouldBe
       Success(Some("Violates 5: invalid state (SUBMITTED)"))
   }
 
@@ -129,7 +131,7 @@ class DatasetFilterSpec extends TestSupportFixture with BagIndexSupport with Moc
     simpleChecker(
           loggerExpectsWarnings = Seq(s"violated 7: is in the vault $result"),
           mockBagIndexRespondsWith(body = s"<result>$result</result>", code = 200),
-        ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), List.empty, exportStates) shouldBe
+        ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), List(fileInfo), List.empty, exportStates) shouldBe
       Success(Some("Violates 7: is in the vault"))
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/ResolverSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/versions/ResolverSpec.scala
@@ -28,8 +28,9 @@ class ResolverSpec extends TestSupportFixture {
       Success("easy-dataset:123")
   }
   it should "find doi" in {
-    Resolver().getDatasetId("10.17026/dans-zjf-522e") match {
-      case Success(s) => s shouldBe "easy-dataset:34340"
+    // might break again when this dataset is migrated to a data-station too
+    Resolver().getDatasetId("10.17026/dans-xgt-zubz") match {
+      case Success(s) => s shouldBe "easy-dataset:246172"
       case Failure(e) => assume(serviceAvailable(e))
     }
   }


### PR DESCRIPTION
Fixes DD-769: nopayload exception turned into a rule violation

#### When applied it will...
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

* Please compile with JDK-8 because of jibx:

      export JAVA_HOME=`/usr/libexec/java_home -v 1.8`

* ...

#### How should this be manually tested?


#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
