### PR TITLE
DD-1239: Point migration-link to description tab in EASY

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -181,7 +181,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
     }
 
     def makelink(datasetId: DatasetId): Node = {
-     <a href={ s"https://easy.dans.knaw.nl/ui/datasets/id/$datasetId/tab/2" }>{ s"https://easy.dans.knaw.nl/ui/datasets/id/$datasetId" }</a>
+     <a href={ s"https://easy.dans.knaw.nl/ui/datasets/id/$datasetId" }>{ s"https://easy.dans.knaw.nl/ui/datasets/id/$datasetId" }</a>
     }
 
     for {

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -161,7 +161,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val metadataDir = dataDirs.head.parent / "metadata"
     (XML.loadFile((metadataDir / "files.xml").toJava) \ "file") shouldBe empty
     (metadataDir / "dataset.xml").contentAsString should
-       include("<![CDATA[<b>Files not yet migrated to Data Station. Files for this dataset can be found at <a href=\"https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:17/tab/2\">https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:17</a>.</b>]]>")
+       include("<![CDATA[<b>Files not yet migrated to Data Station. Files for this dataset can be found at <a href=\"https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:17\">https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:17</a>.</b>]]>")
 
   }
 
@@ -586,7 +586,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     triedRecord shouldBe a[Success[_]]
     (bagDir / "data").list shouldBe empty
     (bagDir / "metadata" / "dataset.xml").contentAsString should include(
-         "<![CDATA[<b>Files not yet migrated to Data Station. Files for this dataset can be found at <a href=\"https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:13/tab/2\">https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:13</a>.</b>]]>"
+         "<![CDATA[<b>Files not yet migrated to Data Station. Files for this dataset can be found at <a href=\"https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:13\">https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:13</a>.</b>]]>"
        )
 
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -586,7 +586,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     triedRecord shouldBe a[Success[_]]
     (bagDir / "data").list shouldBe empty
     (bagDir / "metadata" / "dataset.xml").contentAsString should include(
-         "<![CDATA[<b>Files not yet migrated to Data Station. Files for this dataset can be found at <a href=\"https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:13\">https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:13</a>.</b>]]>"
+         """<![CDATA[<b>Files not yet migrated to Data Station. Files for this dataset can be found at <a href="https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:13">https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:13</a>.</b>]]>"""
        )
 
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/AppSpec.scala
@@ -161,7 +161,7 @@ class AppSpec extends TestSupportFixture with FileFoXmlSupport with BagIndexSupp
     val metadataDir = dataDirs.head.parent / "metadata"
     (XML.loadFile((metadataDir / "files.xml").toJava) \ "file") shouldBe empty
     (metadataDir / "dataset.xml").contentAsString should
-       include("<![CDATA[<b>Files not yet migrated to Data Station. Files for this dataset can be found at <a href=\"https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:17\">https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:17</a>.</b>]]>")
+       include("""<![CDATA[<b>Files not yet migrated to Data Station. Files for this dataset can be found at <a href="https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:17">https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:17</a>.</b>]]>""")
 
   }
 


### PR DESCRIPTION
Fixes DD-1239

#### When applied it will...
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

* Please compile with JDK-8 because of jibx:

      export JAVA_HOME=`/usr/libexec/java_home -v 1.8`

* ...

#### How should this be manually tested?

* [ ] compile (for the sake of jibx for EMD) with

      export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
* ...

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
