### PR TITLE
DD-1558 av location url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,18 @@
         <main-class>nl.knaw.dans.easy.fedoratobag.Command</main-class>
         <easy.emd.version>3.9.2</easy.emd.version>
     </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>7</source>
+                    <target>7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <scm>
         <developerConnection>scm:git:ssh://github.com/DANS-KNAW/${project.artifactId}</developerConnection>

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -287,7 +287,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
           .disseminateDatastream(fileInfo.fedoraFileId, streamId = "EASY_FILE")
           .map(bag.addPayloadFile(_, target))
           .tried.flatten
-        // get checksum from manifest (calculated by addPayload) only if fileInfo has a checksum
+        // if fileInfo has a checksum, try to get the same type of checksum from manifest as calculated by addPayload
         maybeBagChecksum = fileInfo.maybeDigestType.flatMap(getChecksum(file, bag))
         _ <- verifyChecksums(file, fileInfo.maybeDigestValue, maybeBagChecksum)
       } yield ()

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -306,8 +306,9 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       case (Some(_), Some(_)) => Failure(new Exception(
         s"Different checksums in fedora $fedoraValue and exported bag $bagValue for $file"
       ))
-      case _ => logger.warn(s"No checksum in fedora for $file")
+      case (_, None) => logger.warn(s"No checksum in fedora for $file")
         Success(())
+      case _ => Failure(new Exception(s"No checksum in bag (or not the same type as in fedora) for $file"))
     }
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -36,8 +36,10 @@ import nl.knaw.dans.pf.language.emd.EasyMetadataImpl
 import nl.knaw.dans.pf.language.emd.binding.EmdUnmarshaller
 import org.apache.commons.csv.CSVPrinter
 import org.joda.time.DateTime
+import sun.net.util.URLUtil
 
-import java.io.{ IOException, InputStream }
+import java.io.{ ByteArrayInputStream, IOException, InputStream }
+import java.net.URL
 import java.nio.file.Paths
 import java.util.UUID
 import javax.naming.ldap.InitialLdapContext
@@ -272,15 +274,27 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
   private def addPayloadFileTo(bag: DansV0Bag, isOriginalVersioned: Boolean)(fileInfo: FileInfo): Try[Node] = {
     trace(fileInfo)
     val target = fileInfo.path.bagPath(isOriginalVersioned)
-    val file = bag.baseDir / "data" / target.toString
+
+    def saveEmpty = {
+      val emptyStream = new ByteArrayInputStream(Array[Byte]())
+      bag.addPayloadFile(emptyStream, target)
+    }
+
+    def disseminate = {
+      val file = bag.baseDir / "data" / target.toString
+      for {
+        _ <- fedoraProvider
+          .disseminateDatastream(fileInfo.fedoraFileId, streamId = "EASY_FILE")
+          .map(bag.addPayloadFile(_, target))
+          .tried.flatten
+        maybeBagChecksum = fileInfo.maybeDigestType.flatMap(getChecksum(file, bag))
+        _ <- verifyChecksums(file, fileInfo.maybeDigestValue, maybeBagChecksum)
+      } yield ()
+    }
+
     for {
       fileItem <- FileItem(fileInfo, isOriginalVersioned)
-      _ <- fedoraProvider
-        .disseminateDatastream(fileInfo.fedoraFileId, streamId = "EASY_FILE")
-        .map(bag.addPayloadFile(_, target))
-        .tried.flatten
-      maybeBagChecksum = fileInfo.maybeDigestType.flatMap(getChecksum(file, bag))
-      _ <- verifyChecksums(file, fileInfo.maybeDigestValue, maybeBagChecksum)
+      _ <- fileInfo.locationUrl.map(_ => Success(saveEmpty)).getOrElse(disseminate)
     } yield fileItem
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -287,6 +287,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
           .disseminateDatastream(fileInfo.fedoraFileId, streamId = "EASY_FILE")
           .map(bag.addPayloadFile(_, target))
           .tried.flatten
+        // get checksum from manifest (calculated by addPayload) only if fileInfo has a checksum
         maybeBagChecksum = fileInfo.maybeDigestType.flatMap(getChecksum(file, bag))
         _ <- verifyChecksums(file, fileInfo.maybeDigestValue, maybeBagChecksum)
       } yield ()

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileItem.scala
@@ -73,6 +73,7 @@ object FileItem extends DebugEnhancedLogging {
         { fileInfo.additionalMetadata.map(convert).getOrElse( Seq[Node]()) }
         <accessibleToRights>{ fileInfo.accessibleTo }</accessibleToRights>
         <visibleToRights>{ fileInfo.visibleTo }</visibleToRights>
+        { fileInfo.locationUrl.map(url => <dct:source>{ url }</dct:source>).getOrElse(Seq[Node]()) }
         { originalPath }
         { src }
       </file>

--- a/src/test/resources/sample-foxml/invalidUrl.xml
+++ b/src/test/resources/sample-foxml/invalidUrl.xml
@@ -1,0 +1,53 @@
+<foxml:digitalObject xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd"
+                     PID="easy-file:35"
+                     VERSION="1.1"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xmlns:foxml="info:fedora/fedora-system:def/foxml#">
+<foxml:objectProperties>
+        <foxml:property VALUE="Active" NAME="info:fedora/fedora-system:def/model#state"/>
+        <foxml:property VALUE="konijn.mp4" NAME="info:fedora/fedora-system:def/model#label"/>
+        <foxml:property VALUE="easyadmin" NAME="info:fedora/fedora-system:def/model#ownerId"/>
+        <foxml:property VALUE="2016-09-23T15:22:10.477Z" NAME="info:fedora/fedora-system:def/model#createdDate"/>
+        <foxml:property VALUE="2016-09-23T15:22:10.907Z" NAME="info:fedora/fedora-system:def/view#lastModifiedDate"/>
+    </foxml:objectProperties>
+    <foxml:datastream VERSIONABLE="false" CONTROL_GROUP="X" STATE="A" ID="AUDIT">
+        <foxml:datastreamVersion FORMAT_URI="info:fedora/fedora-system:format/xml.fedora.audit" MIMETYPE="text/xml" CREATED="2016-09-23T15:22:10.477Z" LABEL="Audit Trail for this object" ID="AUDIT.0">
+            <foxml:xmlContent>
+                <audit:auditTrail xmlns:audit="info:fedora/fedora-system:def/audit#">
+                </audit:auditTrail>
+            </foxml:xmlContent>
+        </foxml:datastreamVersion>
+    </foxml:datastream>
+    <foxml:datastream VERSIONABLE="true" CONTROL_GROUP="X" STATE="A" ID="DC">
+        <foxml:datastreamVersion SIZE="433" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" MIMETYPE="text/xml" CREATED="2016-09-23T15:22:10.502Z" LABEL="Dublin Core Record" ID="DC1.0">
+            <foxml:xmlContent>
+                <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                    <dc:title>konijn.mp4</dc:title>
+                    <dc:type>video/mp4</dc:type>
+                    <dc:identifier/>
+                </oai_dc:dc>
+            </foxml:xmlContent>
+        </foxml:datastreamVersion>
+    </foxml:datastream>
+    <foxml:datastream VERSIONABLE="true" CONTROL_GROUP="R" STATE="A" ID="EASY_FILE">
+        <foxml:datastreamVersion MIMETYPE="video/mp4" CREATED="2016-09-23T15:22:10.613Z" LABEL="" ID="EASY_FILE.0">
+            <foxml:contentLocation REF="http://legacy-storage.dans.knaw.nl/data/Getuigenverhalen/Project_Het Vergeten_Bombardement/GV_GAR_bombardement_05.mp4" TYPE="URL"/>
+        </foxml:datastreamVersion>
+    </foxml:datastream>
+    <foxml:datastream VERSIONABLE="true" CONTROL_GROUP="X" STATE="A" ID="EASY_FILE_METADATA">
+        <foxml:datastreamVersion SIZE="388" MIMETYPE="text/xml" CREATED="2016-09-23T15:22:10.629Z" LABEL="" ID="EASY_FILE_METADATA.0">
+            <foxml:xmlContent>
+                <fimd:file-item-md version="0.1" xmlns:fimd="http://easy.dans.knaw.nl/easy/file-item-md/">
+                    <name>konijn.mp4</name>
+                    <path>audio-video/konijn.mp4</path>
+                    <mimeType>video/mp4</mimeType>
+                    <size>1055736</size>
+                    <creatorRole>ARCHIVIST</creatorRole>
+                    <visibleTo>NONE</visibleTo>
+                    <accessibleTo>ANONYMOUS</accessibleTo>
+                </fimd:file-item-md>
+            </foxml:xmlContent>
+        </foxml:datastreamVersion>
+    </foxml:datastream>
+
+</foxml:digitalObject>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileInfosSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileInfosSpec.scala
@@ -92,7 +92,22 @@ class FileInfosSpec extends TestSupportFixture with FileFoXmlSupport with MockFa
       case Success(List(fileInfo: FileInfo)) if
         fileInfo.name == "a_cקq_e_g_i_k_m_o_.txt" &&
         fileInfo.path.toString == "pשr_e_t_/t_/s_m_w_e_e_f/a_cקq_e_g_i_k_m_o_.pdf" &&
-        fileInfo.originalPath.toString == "pשr(e:t*/t?/s>m|w;e#e'f/a:cקq*e?g>i|k;m#o\".pdf"
+        fileInfo.originalPath.toString == "pשr(e:t*/t?/s>m|w;e#e'f/a:cקq*e?g>i|k;m#o\".pdf" &&
+        fileInfo.locationUrl.isEmpty
+      =>
+    }
+  }
+
+  "FileInfo" should "get a provided content location" in {
+    val foxml = XML.loadFile("src/test/resources/sample-foxml/invalidUrl.xml")
+    val fedoraProvider = mock[FedoraProvider]
+    (fedoraProvider.loadFoXml(_: String)) expects "easy-file:35" once() returning Success(foxml)
+
+    val triedInfoes = FileInfo(List("easy-file:35"), fedoraProvider)
+    triedInfoes should matchPattern {
+      case Success(List(fileInfo: FileInfo)) if
+        fileInfo.name == "konijn.mp4" &&
+        fileInfo.locationUrl.contains("http://legacy-storage.dans.knaw.nl/data/Getuigenverhalen/Project_Het Vergeten_Bombardement/GV_GAR_bombardement_05.mp4")
       =>
     }
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
@@ -170,6 +170,26 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
     }
   }
 
+  it should "add location url" in {
+    val fileInfo = callFileInfo(Map(
+      "easy-file:35" -> XML.loadFile("src/test/resources/sample-foxml/invalidUrl.xml",
+      ))).getOrElse(fail).head
+
+    val triedFileItem = FileItem(fileInfo, isOriginalVersioned = false)
+    triedFileItem.map(trim) shouldBe Success(trim(
+      <file filepath="data/audio-video/konijn.mp4">
+        <dct:identifier>easy-file:35</dct:identifier>
+        <dct:title>konijn.mp4</dct:title>
+        <dct:format>video/mp4</dct:format>
+        <dct:extent>1.0MB</dct:extent>
+        <accessibleToRights>NONE</accessibleToRights>
+        <visibleToRights>NONE</visibleToRights>
+        <dct:source>http://legacy-storage.dans.knaw.nl/data/Getuigenverhalen/Project_Het Vergeten_Bombardement/GV_GAR_bombardement_05.mp4</dct:source>
+      </file>
+    ))
+
+  }
+
   it should "map key-value pairs" in {
     val fileMetadata = {
       <sid>easy-file:3165833</sid>

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/FileFoXmlSupport.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/fixture/FileFoXmlSupport.scala
@@ -36,7 +36,12 @@ trait FileFoXmlSupport {
                 digest: String = "dd466d19481a28ba8577e7b3f029e496027a3309",
                 creatorRole: String = "DEPOSITOR",
                 derivedFrom: Option[Int] = None,
+                contentUrl: Option[String] = None
                ): Elem = {
+    val contentLocation = contentUrl
+      .map(url => <foxml:contentLocation TYPE="URL" REF={ url }/>)
+      .getOrElse(<foxml:contentLocation TYPE="INTERNAL_ID" REF={ s"easy-file:$id+EASY_FILE+EASY_FILE.0" }/>)
+
     <foxml:digitalObject VERSION="1.1" PID={s"easy-file:$id"}
                      xmlns:foxml="info:fedora/fedora-system:def/foxml#"
                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -51,7 +56,7 @@ trait FileFoXmlSupport {
       <foxml:datastream ID="EASY_FILE" STATE="A" CONTROL_GROUP="M" VERSIONABLE="false">
           <foxml:datastreamVersion ID="EASY_FILE.0" LABEL="" CREATED="2020-03-17T10:24:17.542Z" MIMETYPE={ mimeType } SIZE={ size.toString }>
               <foxml:contentDigest TYPE="SHA-1" DIGEST={ digest }/>
-              <foxml:contentLocation TYPE="INTERNAL_ID" REF={ s"easy-file:$id+EASY_FILE+EASY_FILE.0" }/>
+              { contentLocation }
           </foxml:datastreamVersion>
       </foxml:datastream>
       <foxml:datastream ID="EASY_FILE_METADATA" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">


### PR DESCRIPTION
Fixes EASY-DD-1558 av location url

#### When applied it will...
* see commits
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

* Please compile with JDK-8 because of jibx:

      export JAVA_HOME=`/usr/libexec/java_home -v 1.8`

* ...

#### How should this be manually tested?

* [ ] compile (for the sake of jibx for EMD) with

      export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
* ...

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
