### PR TITLE
DD-1581: AV - accessrights as in easy whoops

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ ARGUMENTS
          --skip-list  <arg>       File containing a newline-separated list of easy-dataset-ids to be skipped
      -s, --strict                 If provided, the transformation will check whether the datasets adhere to the
                                   requirements of the chosen transformation.
+     -w, --with-AV                accsssible to value is not changed
      -h, --help                   Show help message
      -v, --version                Show version of this program
     

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Command.scala
@@ -36,6 +36,7 @@ object Command extends App with DebugEnhancedLogging {
     verify()
   }
 
+  private val withAV = commandLine.withAv()
   private val europeana = commandLine.europeana()
   private val csvLogFile = commandLine.logFile()
 
@@ -49,7 +50,7 @@ object Command extends App with DebugEnhancedLogging {
     Try(commandLine.transformation() match {
       case ORIGINAL_VERSIONED if !isAip => SimpleDatasetFilter(allowOriginalAndOthers = true)
       case THEMA if isAip => ThemaDatasetFilter(allowOriginalAndOthers = europeana, targetIndex = app.bagIndex)
-      case SIMPLE if isAip => SimpleDatasetFilter(allowOriginalAndOthers = europeana, targetIndex = app.bagIndex)
+      case SIMPLE if isAip => SimpleDatasetFilter(allowOriginalAndOthers = europeana, withAV = withAV, targetIndex = app.bagIndex)
       case SIMPLE => SimpleDatasetFilter(allowOriginalAndOthers = europeana)
       case _ => throw new NotImplementedError(s"${ commandLine.args } not implemented")
     }).flatMap { datasetFilter =>
@@ -58,7 +59,7 @@ object Command extends App with DebugEnhancedLogging {
         commandLine.datasetId.map(di => List(InputFileRecord(di))).getOrElse(loadInputFile(commandLine.inputFile()).get),
         commandLine.skipDatasets.toOption.map(skipDatasets => readDatasetIds(skipDatasets).toSeq).getOrElse(Seq.empty),
         commandLine.outputDir(),
-        Options(datasetFilter, commandLine.transformation(), commandLine.strictMode(), europeana, commandLine.noPayload(), commandLine.cutoff()),
+        Options(datasetFilter, commandLine.transformation(), commandLine.strictMode(), europeana, commandLine.noPayload(), commandLine.cutoff(), commandLine.withAv()),
         commandLine.outputFormat(),
       ))
     }

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/CommandLineOptions.scala
@@ -50,6 +50,8 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   implicit val outputFormatConverter: ValueConverter[OutputFormat] = singleArgConverter(OutputFormat.withName)
   implicit val fileConverter: ValueConverter[File] = singleArgConverter(File(_))
 
+  val withAv: ScallopOption[Boolean] = opt(name = "with-AV",
+    descr = "accsssible to value is not changed")
   val datasetId: ScallopOption[DatasetId] = opt(name = "datasetId", short = 'd',
     descr = "A single easy-dataset-id to be transformed. Use either this or the input-file argument")
   val inputFile: ScallopOption[File] = opt(name = "input-file", short = 'i',

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/EasyFedoraToBagApp.scala
@@ -198,7 +198,7 @@ class EasyFedoraToBagApp(configuration: Configuration) extends DebugEnhancedLogg
       fedoraFileIDs <- if (options.noPayload) Success(Seq.empty)
                        else fsRdb.getSubordinates(datasetId)
       isOriginalVersioned = options.transformationType == ORIGINAL_VERSIONED
-      allFileInfos <- FileInfo(fedoraFileIDs, fedoraProvider).map(_.toList)
+      allFileInfos <- FileInfo(fedoraFileIDs, fedoraProvider, options.withAv).map(_.toList)
       selectedForSecondBag = allFileInfos.selectForSecondBag(isOriginalVersioned, options.noPayload)
       selectedForFirstBag <- getInfoFirstBag(allFileInfos, emdXml, selectedForSecondBag.nonEmpty)
       skipPayload = noPayload(selectedForSecondBag, selectedForFirstBag)

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/FileInfo.scala
@@ -72,7 +72,7 @@ object FileInfo extends DebugEnhancedLogging {
     Paths.get(s)
   }
 
-  def apply(fedoraIDs: Seq[String], fedoraProvider: FedoraProvider): Try[Seq[FileInfo]] = {
+  def apply(fedoraIDs: Seq[String], fedoraProvider: FedoraProvider, withAv: Boolean): Try[Seq[FileInfo]] = {
 
     def digestValue(foXmlStream: Option[Node]): Option[Node] = foXmlStream
       .map(_ \\ "contentDigest").flatMap(_.headOption)
@@ -121,7 +121,7 @@ object FileInfo extends DebugEnhancedLogging {
             .getOrElse(throw new Exception(s"$fileId <$tag> not found"))
 
           val visibleTo = get("visibleTo")
-          val accessibleTo = if ("NONE" == visibleTo.toUpperCase) "NONE"
+          val accessibleTo = if ("NONE" == visibleTo.toUpperCase && !withAv) "NONE"
                              else get("accessibleTo")
           new FileInfo(
             fileId, path,

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/Options.scala
@@ -30,4 +30,5 @@ case class Options(datasetFilter: DatasetFilter,
                    europeana: Boolean = false,
                    noPayload: Boolean = false,
                    cutoff: Int = Int.MaxValue,
+                   withAv: Boolean = false,
                   )

--- a/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/SimpleDatasetFilter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedoratobag/filter/SimpleDatasetFilter.scala
@@ -24,6 +24,7 @@ class SimpleDatasetFilter(override val allowOriginalAndOthers: Boolean = false,
 }
 object SimpleDatasetFilter {
   def apply(allowOriginalAndOthers: Boolean = false,
+            withAV: Boolean = false,
             targetIndex: TargetIndex = new TargetIndex(),
            ) =
     new SimpleDatasetFilter(allowOriginalAndOthers, targetIndex)

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileInfosSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileInfosSpec.scala
@@ -76,10 +76,36 @@ class FileInfosSpec extends TestSupportFixture with FileFoXmlSupport with MockFa
     val fedoraProvider = mock[FedoraProvider]
     (fedoraProvider.loadFoXml(_: String)) expects "easy-file:35" once() returning Success(foxml)
 
-    val fileInfo = FileInfo(List("easy-file:35"), fedoraProvider)
+    val fileInfo = FileInfo(List("easy-file:35"), fedoraProvider, withAv = false)
       .getOrElse(fail("could not load test data")).head
     fileInfo.name shouldBe "a_cקq_e_g_i_k_m_o_.txt"
     fileInfo.path shouldBe Paths.get("pשr_e_t_/t_/s_m_w_e_e_f/a_cקq_e_g_i_k_m_o_.txt")
+  }
+  "FileInfo" should "keep original rights" in {
+    val foxml = fileFoXml(
+      visibleTo = "NONE",
+      accessibleTo = "ANONYMOUS",
+    )
+    val fedoraProvider = mock[FedoraProvider]
+    (fedoraProvider.loadFoXml(_: String)) expects "easy-file:35" once() returning Success(foxml)
+
+    val fileInfo = FileInfo(List("easy-file:35"), fedoraProvider, withAv = true)
+      .getOrElse(fail("could not load test data")).head
+    fileInfo.visibleTo shouldBe "NONE"
+    fileInfo.accessibleTo shouldBe "ANONYMOUS"
+  }
+  "FileInfo" should "override rights" in {
+    val foxml = fileFoXml(
+      visibleTo = "NONE",
+      accessibleTo = "ANONYMOUS",
+    )
+    val fedoraProvider = mock[FedoraProvider]
+    (fedoraProvider.loadFoXml(_: String)) expects "easy-file:35" once() returning Success(foxml)
+
+    val fileInfo = FileInfo(List("easy-file:35"), fedoraProvider, withAv = false)
+      .getOrElse(fail("could not load test data")).head
+    fileInfo.visibleTo shouldBe "NONE"
+    fileInfo.accessibleTo shouldBe "NONE"
   }
 
   "FileInfo" should "not stumble over an inconsistent file name" in {
@@ -87,7 +113,7 @@ class FileInfosSpec extends TestSupportFixture with FileFoXmlSupport with MockFa
     val fedoraProvider = mock[FedoraProvider]
     (fedoraProvider.loadFoXml(_: String)) expects "easy-file:35" once() returning Success(foxml)
 
-    val triedInfoes = FileInfo(List("easy-file:35"), fedoraProvider)
+    val triedInfoes = FileInfo(List("easy-file:35"), fedoraProvider, withAv = false)
     triedInfoes should matchPattern {
       case Success(List(fileInfo: FileInfo)) if
         fileInfo.name == "a_cקq_e_g_i_k_m_o_.txt" &&
@@ -103,7 +129,7 @@ class FileInfosSpec extends TestSupportFixture with FileFoXmlSupport with MockFa
     val fedoraProvider = mock[FedoraProvider]
     (fedoraProvider.loadFoXml(_: String)) expects "easy-file:35" once() returning Success(foxml)
 
-    val triedInfoes = FileInfo(List("easy-file:35"), fedoraProvider)
+    val triedInfoes = FileInfo(List("easy-file:35"), fedoraProvider, withAv = false)
     triedInfoes should matchPattern {
       case Success(List(fileInfo: FileInfo)) if
         fileInfo.name == "konijn.mp4" &&
@@ -122,7 +148,7 @@ class FileInfosSpec extends TestSupportFixture with FileFoXmlSupport with MockFa
     val fedoraProvider = mock[FedoraProvider]
     (fedoraProvider.loadFoXml(_: String)) expects "easy-file:35" once() returning Success(foxml)
 
-    val fileInfo = FileInfo(List("easy-file:35"), fedoraProvider)
+    val fileInfo = FileInfo(List("easy-file:35"), fedoraProvider, withAv = false)
       .getOrElse(fail("could not load test data")).head
     fileInfo.name shouldBe "a(b)c,d'e[f]g&h+i.txt"
     fileInfo.path shouldBe Paths.get("k_l_m_n_o_p_q_r_s/a(b)c,d'e[f]g&h+i.txt")

--- a/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedoratobag/FileItemSpec.scala
@@ -488,7 +488,7 @@ class FileItemSpec extends TestSupportFixture with MockFactory with SchemaSuppor
     foXMLs.foreach { case (id, xml) =>
       (fedoraProvider.loadFoXml(_: String)) expects id once() returning Success(xml)
     }
-    val triedFileInfos = FileInfo(foXMLs.keys.toList, fedoraProvider)
+    val triedFileInfos = FileInfo(foXMLs.keys.toList, fedoraProvider, false)
     triedFileInfos
   }
 


### PR DESCRIPTION
Fixes DD-1581: AV - accessrights as in easy whoops

#### When applied it will...
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

* Please compile with JDK-8 because of jibx:

      export JAVA_HOME=`/usr/libexec/java_home -v 1.8`

* ...

#### How should this be manually tested?

* [ ] compile (for the sake of jibx for EMD) with

      export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
* ...

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
